### PR TITLE
Taking inplace Jacobian for AbstractArray

### DIFF
--- a/src/finitediff.jl
+++ b/src/finitediff.jl
@@ -160,7 +160,7 @@ function finite_difference_jacobian!(J::AbstractArray{T}, f, x::AbstractArray{T}
     # This is an inefficient fallback that only makes sense if setindex/getindex are unavailable, e.g. GPUArrays etc.
     m, n = size(J)
     epsilon_factor = compute_epsilon_factor(fdtype, T)
-    if t == Val{:forward}
+    if fdtype == Val{:forward}
         shifted_x = copy(x)
         for i in 1:n
             epsilon = compute_epsilon(t, x[i], epsilon_factor)
@@ -168,11 +168,11 @@ function finite_difference_jacobian!(J::AbstractArray{T}, f, x::AbstractArray{T}
             J[:, i] .= (f(shifted_x) - f_x) / epsilon
             shifted_x[i] = x[i]
         end
-    elseif t == Val{:central}
+    elseif fdtype == Val{:central}
         shifted_x_plus  = copy(x)
         shifted_x_minus = copy(x)
         for i in 1:n
-            epsilon = compute_epsilon(t, x[i], epsilon_factor)
+            epsilon = compute_epsilon(fdtype, x[i], epsilon_factor)
             shifted_x_plus[i]  += epsilon
             shifted_x_minus[i] -= epsilon
             J[:, i] .= (f(shifted_x_plus) - f(shifted_x_minus)) / (epsilon + epsilon)


### PR DESCRIPTION
The following code will work after this fix.

```julia
julia> using BandedMatrices

julia> mutable struct BVPJacobianWrapper{LossType,CacheType} <: Function
         loss::LossType
         x1::CacheType
         fx1::CacheType
       end

julia> (p::BVPJacobianWrapper)(resid,u) = p.loss(u,resid)

julia> (p::BVPJacobianWrapper)(u) = (resid = similar(u); p.loss(u,resid); resid)

julia> loss!(x, resid) = @. resid = sin(tan(x)) * cos(x)
loss! (generic function with 1 method)

julia> f! = BVPJacobianWrapper(loss!, Vector{Float64}(5), Vector{Float64}(5)); J = bzeros(5,5,1,1); x = ones(5); resid = similar(x)
5-element Array{Float64,1}:
 0.0
 0.0
 0.0
 0.0
 0.0

julia> DiffEqDiffTools.finite_difference_jacobian!(J, f!, x, Val{:central}, resid, Val{:JacobianWrapper})
5×5 BandedMatrices.BandedMatrix{Float64}:
 -0.816616   0.0
  0.0       -0.816616   0.0
             0.0       -0.816616   0.0
                        0.0       -0.816616   0.0
                                   0.0       -0.816616
```