### PR TITLE
remove df

### DIFF
--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -1,32 +1,29 @@
 # Compute the Jacobian matrix of a real-valued callable f.
 function finite_difference_jacobian(f, x::AbstractArray{<:Number},
-    fdtype::DataType=Val{:central}, funtype::DataType=Val{:Real}, wrappertype::DataType=Val{:Default},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x),
-    df::Union{Void,AbstractArray{<:Number}}=nothing)
+    fdtype::DataType=Val{:central}, funtype::DataType=Val{:Real},
+    wrappertype::DataType=Val{:Default},
+    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x))
 
     J = zeros(returntype, length(x), length(x))
-    finite_difference_jacobian!(J, f, x, fdtype, funtype, wrappertype, fx, epsilon, returntype, df)
+    finite_difference_jacobian!(J, f, x, fdtype, funtype, wrappertype, fx,
+                                epsilon, returntype)
 end
 
-function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, df::AbstractVector, f, x::AbstractArray{<:Number},
-    fdtype::DataType=Val{:central}, funtype::DataType=Val{:Real}, wrappertype::DataType=Val{:Default},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Number}}=nothing, returntype=eltype(x))
+function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, f,
+    x::AbstractArray{<:Number},
+    fdtype::DataType=Val{:central}, funtype::DataType=Val{:Real},
+    wrappertype::DataType=Val{:Default},
+    fx::Union{Void,AbstractArray{<:Number}}=nothing,
+    epsilon::Union{Void,AbstractArray{<:Number}}=nothing, returntype=eltype(x))
 
-    finite_difference_jacobian!(J, f, x, fdtype, funtype, wrappertype, fx, epsilon, returntype, df)
+    finite_difference_jacobian!(J, f, x, fdtype, funtype, wrappertype, fx, epsilon, returntype)
 end
 
-function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
-    fdtype::DataType=Val{:central}, funtype::DataType=Val{:Real}, wrappertype::DataType=Val{:Default},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Number}}=nothing, returntype=eltype(x),
-    df::Union{Void,AbstractArray{<:Number}}=nothing)
-
-    finite_difference_jacobian!(J, f, x, fdtype, funtype, wrappertype, fx, epsilon, returntype, df)
-end
-
-function finite_difference_jacobian!(J::AbstractMatrix{<:Real}, f, x::AbstractArray{<:Real},
+function finite_difference_jacobian!(J::AbstractMatrix{<:Real}, f,
+    x::AbstractArray{<:Real},
     fdtype::DataType, ::Type{Val{:Real}}, ::Type{Val{:Default}},
-    fx::Union{Void,AbstractArray{<:Real}}=nothing, epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x),
-    df::Union{Void,AbstractArray{<:Real}}=nothing)
+    fx::Union{Void,AbstractArray{<:Real}}=nothing,
+    epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x))
 
     # TODO: test and rework this to support GPUArrays and non-indexable types, if possible
     m, n = size(J)
@@ -66,16 +63,13 @@ function finite_difference_jacobian!(J::AbstractMatrix{<:Real}, f, x::AbstractAr
     else
         fdtype_error(Val{:Real})
     end
-    if typeof(df) != Void
-        df .= diag(J)
-    end
     J
 end
 
-function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, f, x::AbstractArray{<:Number},
+function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, f,
+    x::AbstractArray{<:Number},
     fdtype::DataType, ::Type{Val{:Complex}}, ::Type{Val{:Default}},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x),
-    df::Union{Void,AbstractArray{<:Number}}=nothing)
+    fx::Union{Void,AbstractArray{<:Number}}=nothing, epsilon::Union{Void,AbstractArray{<:Real}}=nothing, returntype=eltype(x))
 
     # TODO: test and rework this to support GPUArrays and non-indexable types, if possible
     m, n = size(J)
@@ -106,9 +100,6 @@ function finite_difference_jacobian!(J::AbstractMatrix{<:Number}, f, x::Abstract
         end
     else
         fdtype_error(Val{:Complex})
-    end
-    if typeof(df) != Void
-        df .= diag(J)
     end
     J
 end

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -108,29 +108,6 @@ epsilon = zeros(x)
     @test err_func(DiffEqDiffTools.finite_difference_jacobian!(J, f, x, Val{:complex}, Val{:Real}, Val{:Default}, y, epsilon), J_ref) < 1e-14
 end
 
-# Jacobian tests w/ derivatives (real-valued callables)
-@time @testset "Jacobian StridedArray real-valued derivative tests" begin
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward})
-    @show df, df_ref
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central})
-    @test err_func(df, df_ref) < 1e-8
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:complex})
-    @test err_func(df, df_ref) < 1e-15
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward}, Val{:Real}, Val{:Default}, y)
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central}, Val{:Real}, Val{:Default}, y)
-    @test err_func(df, df_ref) < 1e-8
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:complex}, Val{:Real}, Val{:Default}, y)
-    @test err_func(df, df_ref) < 1e-15
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward}, Val{:Real}, Val{:Default}, y, epsilon)
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central}, Val{:Real}, Val{:Default}, y, epsilon)
-    @test err_func(df, df_ref) < 1e-8
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:complex}, Val{:Real}, Val{:Default}, y, epsilon)
-    @test err_func(df, df_ref) < 1e-15
-end
-
 function f(x)
     fvec = zeros(x)
     fvec[1] = (im*x[1]+3)*(x[2]^3-7)+18
@@ -166,19 +143,4 @@ epsilon = zeros(real.(x))
     @test err_func(DiffEqDiffTools.finite_difference_jacobian!(J, f, x, Val{:central}, Val{:Complex}, Val{:Default}, y, epsilon), J_ref) < 1e-8
 end
 
-# Jacobian tests w/ derivatives (complex-valued callables)
-@time @testset "Jacobian StridedArray complex-valued derivative tests" begin
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward}, Val{:Complex}, Val{:Default})
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central}, Val{:Complex}, Val{:Default})
-    @test err_func(df, df_ref) < 1e-8
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward}, Val{:Complex}, Val{:Default}, y)
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central}, Val{:Complex}, Val{:Default}, y)
-    @test err_func(df, df_ref) < 1e-8
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:forward}, Val{:Complex}, Val{:Default}, y, epsilon)
-    @test err_func(df, df_ref) < 1e-4
-    DiffEqDiffTools.finite_difference_jacobian!(J, df, f, x, Val{:central}, Val{:Complex}, Val{:Default}, y, epsilon)
-    @test err_func(df, df_ref) < 1e-8
-end
 # StridedArray tests end here


### PR DESCRIPTION
This comes from miscommunication in https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/16 , where I thought having df could make calculations cheaper, and @dextorious only agreed because he thought it was supposed to be the gradient. Instead, it is the function evaluation at x, which only happens in forward differentiation. But since the number of function evaluations is n^2, it seems silly to specialize for just that one version of finite differencing to cut off 1 function evaulation, so instead I think we should just get rid of this and have NLsolve's `fj!` just do an extra function eval in all cases

@pkofod