### PR TITLE
Fix complex scalar finite difference

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -136,10 +136,10 @@ function _finite_difference!(df::StridedArray{<:Number}, f, x::Number,
 
     epsilon_elemtype = compute_epsilon_elemtype(epsilon, x)
     if fdtype == Val{:forward}
-        epsilon = compute_epsilon(Val{:forward}, real(x[i]))
+        epsilon = compute_epsilon(Val{:forward}, real(x))
         df .= ( real( f(x+epsilon) - f(x) ) + im*imag( f(x+im*epsilon) - f(x) ) ) / epsilon
     elseif fdtype == Val{:central}
-        epsilon = compute_epsilon(Val{:central}, real(x[i]))
+        epsilon = compute_epsilon(Val{:central}, real(x))
         df .= (real(f(x+epsilon) - f(x-epsilon)) + im*imag(f(x+im*epsilon) - f(x-im*epsilon))) / (2 * epsilon)
     else
         fdtype_error(Val{:Complex})
@@ -201,7 +201,7 @@ end
 end
 
 @inline function finite_difference_kernel(f, x::Number, ::Type{Val{:forward}}, ::Type{Val{:Complex}}, epsilon::Real, fx::Union{Void,<:Number}=nothing)
-    return real((f(x[i]+epsilon) - f(x[i]))) / epsilon + im*imag((f(x[i]+im*epsilon) - f(x[i]))) / epsilon
+    return real((f(x+epsilon) - f(x))) / epsilon + im*imag((f(x+im*epsilon) - f(x))) / epsilon
 end
 
 @inline function finite_difference_kernel(f, x::Number, ::Type{Val{:central}}, ::Type{Val{:Complex}}, epsilon::Real, fx::Union{Void,<:Number}=nothing)

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -115,3 +115,18 @@ central_cache = DiffEqDiffTools.JacobianCache(similar(x),similar(x),similar(x))
 end
 
 # StridedArray tests end here
+
+# Tests for C -> C and C -> C^n
+x = 2.0 + im*3.0
+f(x) = cos(real(x)) + im*log(imag(x))
+y = f(x)
+df_ref = -sin(real(x)) + im*1/imag(x)
+
+@time @testset "Derivative Number complex-valued tests" begin
+    # Finite difference kernel.
+    @test err_func(DiffEqDiffTools.finite_difference(f, x, Val{:forward}, Val{:Complex}, y), df_ref) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference(f, x, Val{:central}, Val{:Complex}, y), df_ref) < 1e-10
+    # C -> C^n
+    @test err_func(DiffEqDiffTools.finite_difference(f, x, Val{:forward}, Val{:Complex}, [y]), df_ref) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference(f, x, Val{:central}, Val{:Complex}, [y]), df_ref) < 1e-10
+end


### PR DESCRIPTION
Some of the methods for finite differencing required an index `i` which was not defined. It looks to me like something went wrong with a copy paste job. I also added tests for the affected methods. I came across this when I was doing something along the lines of:
```julia
using DifferentialEquations

function f!(t, u, du)
    du .= [2u[2] ; im*u[1]^2]
end

prob = ODEProblem(f!, im*[1.9 ; 2.0], (0.0,1.0))
sol = solve(prob, Rosenbrock23(autodiff=false, diff_type=Val{:central}))
```