### PR TITLE
Changes for 0.7; includes a possibly non-kosher API change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.7
+  # - 0.7
   - nightly
 # matrix:
 #   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
   - linux
 #  - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+# matrix:
+#   allow_failures:
+#     - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.6
+Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.7
+julia 0.7.0-DEV.4000
 Compat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  # - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  # - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
-matrix:
-  allow_failures:
-    - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+# matrix:
+#   allow_failures:
+#     - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+#     - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/src/DiffEqDiffTools.jl
+++ b/src/DiffEqDiffTools.jl
@@ -2,10 +2,13 @@ __precompile__()
 
 module DiffEqDiffTools
 
+using Compat
+
 include("function_wrappers.jl")
 include("finitediff.jl")
 include("derivatives.jl")
 include("gradients.jl")
 include("jacobians.jl")
+include("old_val_api.jl")
 
 end # module

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -2,7 +2,7 @@
 Single-point derivatives of scalar->scalar maps.
 =#
 function finite_difference_derivative(f, x::T, fdtype::Type{T1}=Val{:central},
-    returntype::Type{T2}=eltype(x), f_x::Union{Void,T}=nothing) where {T<:Number,T1,T2}
+    returntype::Type{T2}=eltype(x), f_x::Union{Nothing,T}=nothing) where {T<:Number,T1,T2}
 
     epsilon = compute_epsilon(fdtype, x)
     if fdtype==Val{:forward}
@@ -27,8 +27,8 @@ end
 
 function DerivativeCache(
     x          :: AbstractArray{<:Number},
-    fx         :: Union{Void,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Void,AbstractArray{<:Real}} = nothing,
+    fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing,
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(x)) where {T1,T2}
 
@@ -36,7 +36,7 @@ function DerivativeCache(
         fdtype_error(returntype)
     end
 
-    if fdtype!=Val{:forward} && typeof(fx)!=Void
+    if fdtype!=Val{:forward} && typeof(fx)!=Nothing
         warn("Pre-computed function values are only useful for fdtype==Val{:forward}.")
         _fx = nothing
     else
@@ -44,14 +44,14 @@ function DerivativeCache(
         _fx = fx
     end
 
-    if typeof(epsilon)!=Void && typeof(x)<:StridedArray && typeof(fx)<:Union{Void,StridedArray} && 1==2
+    if typeof(epsilon)!=Nothing && typeof(x)<:StridedArray && typeof(fx)<:Union{Nothing,StridedArray} && 1==2
         warn("StridedArrays don't benefit from pre-allocating epsilon.")
         _epsilon = nothing
-    elseif typeof(epsilon)!=Void && fdtype==Val{:complex}
+    elseif typeof(epsilon)!=Nothing && fdtype==Val{:complex}
         warn("Val{:complex} makes the epsilon array redundant.")
         _epsilon = nothing
     else
-        if typeof(epsilon)==Void || eltype(epsilon)!=real(eltype(x))
+        if typeof(epsilon)==Nothing || eltype(epsilon)!=real(eltype(x))
             epsilon = zeros(real(eltype(x)), size(x))
         end
         _epsilon = epsilon
@@ -67,8 +67,8 @@ function finite_difference_derivative(
     x          :: AbstractArray{<:Number},
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(x),      # return type of f
-    fx         :: Union{Void,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Void,AbstractArray{<:Real}} = nothing) where {T1,T2}
+    fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing) where {T1,T2}
 
     df = zeros(returntype, size(x))
     finite_difference_derivative!(df, f, x, fdtype, returntype, fx, epsilon)
@@ -80,8 +80,8 @@ function finite_difference_derivative!(
     x          :: AbstractArray{<:Number},
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(x),
-    fx         :: Union{Void,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Void,AbstractArray{<:Real}}   = nothing) where {T1,T2}
+    fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}}   = nothing) where {T1,T2}
 
     cache = DerivativeCache(x, fx, epsilon, fdtype, returntype)
     finite_difference_derivative!(df, f, x, cache)
@@ -91,12 +91,12 @@ function finite_difference_derivative!(df::AbstractArray{<:Number}, f, x::Abstra
     cache::DerivativeCache{T1,T2,fdtype,returntype}) where {T1,T2,fdtype,returntype}
 
     fx, epsilon = cache.fx, cache.epsilon
-    if typeof(epsilon) != Void
+    if typeof(epsilon) != Nothing
         epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
         @. epsilon = compute_epsilon(fdtype, x, epsilon_factor)
     end
     if fdtype == Val{:forward}
-        if typeof(fx) == Void
+        if typeof(fx) == Nothing
             @. df = (f(x+epsilon) - f(x)) / epsilon
         else
             @. df = (f(x+epsilon) - fx) / epsilon
@@ -115,7 +115,7 @@ end
 #=
 Optimized implementations for StridedArrays.
 Essentially, the only difference between these and the AbstractArray case
-is that here we can compute the epsilon one by one in local variables and avoid caching it.
+is that here we can compute the epsilon one by one in local variables and aNothing caching it.
 =#
 function finite_difference_derivative!(df::StridedArray, f, x::StridedArray,
     cache::DerivativeCache{T1,T2,fdtype,returntype}) where {T1,T2,fdtype,returntype}
@@ -126,7 +126,7 @@ function finite_difference_derivative!(df::StridedArray, f, x::StridedArray,
         @inbounds for i ∈ eachindex(x)
             epsilon = compute_epsilon(Val{:forward}, x[i], epsilon_factor)
             x_plus = x[i] + epsilon
-            if typeof(fx) == Void
+            if typeof(fx) == Nothing
                 df[i] = (f(x_plus) - f(x[i])) / epsilon
             else
                 df[i] = (f(x_plus) - fx[i]) / epsilon

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -24,7 +24,6 @@ struct DerivativeCache{CacheType1, CacheType2, fdtype, returntype}
     fx      :: CacheType1
     epsilon :: CacheType2
 end
-
 function DerivativeCache(
     x          :: AbstractArray{<:Number},
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
@@ -37,7 +36,7 @@ function DerivativeCache(
     end
 
     if fdtype!=:forward && typeof(fx)!=Nothing
-        warn("Pre-computed function values are only useful for fdtype==Val(:forward).")
+        Compat.@warn "Pre-computed function values are only useful for fdtype==Val(:forward)."
         _fx = nothing
     else
         # more runtime sanity checks?
@@ -45,10 +44,10 @@ function DerivativeCache(
     end
 
     if typeof(epsilon)!=Nothing && typeof(x)<:StridedArray && typeof(fx)<:Union{Nothing,StridedArray} && 1==2
-        warn("StridedArrays don't benefit from pre-allocating epsilon.")
+        Compat.@warn "StridedArrays don't benefit from pre-allocating epsilon."
         _epsilon = nothing
     elseif typeof(epsilon)!=Nothing && fdtype==:complex
-        warn("Val(:complex) makes the epsilon array redundant.")
+        Compat.@warn "Val(:complex) makes the epsilon array redundant."
         _epsilon = nothing
     else
         if typeof(epsilon)==Nothing || eltype(epsilon)!=real(eltype(x))
@@ -58,6 +57,8 @@ function DerivativeCache(
     end
     DerivativeCache{typeof(_fx),typeof(_epsilon),fdtype,returntype}(_fx,_epsilon)
 end
+
+
 
 #=
 Compute the derivative df of a scalar-valued map f at a collection of points x.

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -1,15 +1,15 @@
 #=
 Single-point derivatives of scalar->scalar maps.
 =#
-function finite_difference_derivative(f, x::T, fdtype::Type{T1}=Val{:central},
-    returntype::Type{T2}=eltype(x), f_x::Union{Nothing,T}=nothing) where {T<:Number,T1,T2}
+function finite_difference_derivative(f, x::T, ::Val{fdtype}=Val{:central}(),
+    returntype::Type{T1}=eltype(x), f_x::Union{Nothing,T}=nothing) where {T<:Number,fdtype,T1}
 
-    epsilon = compute_epsilon(fdtype, x)
-    if fdtype==Val{:forward}
+    epsilon = compute_epsilon(Val{fdtype}(), x)
+    if fdtype==:forward
         return (f(x+epsilon) - f(x)) / epsilon
-    elseif fdtype==Val{:central}
+    elseif fdtype==:central
         return (f(x+epsilon) - f(x-epsilon)) / (2*epsilon)
-    elseif fdtype==Val{:complex} && returntype<:Real
+    elseif fdtype==:complex && returntype<:Real
         return imag(f(x+im*epsilon)) / epsilon
     end
     fdtype_error(returntype)
@@ -29,15 +29,15 @@ function DerivativeCache(
     x          :: AbstractArray{<:Number},
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
     epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing,
-    fdtype     :: Type{T1} = Val{:central},
-    returntype :: Type{T2} = eltype(x)) where {T1,T2}
+               :: Val{fdtype} = Val{:central}(),
+    returntype :: Type{T} = eltype(x)) where {fdtype,T}
 
-    if fdtype==Val{:complex} && !(eltype(returntype)<:Real)
+    if fdtype==:complex && !(eltype(returntype)<:Real)
         fdtype_error(returntype)
     end
 
-    if fdtype!=Val{:forward} && typeof(fx)!=Nothing
-        warn("Pre-computed function values are only useful for fdtype==Val{:forward}.")
+    if fdtype!=:forward && typeof(fx)!=Nothing
+        warn("Pre-computed function values are only useful for fdtype==Val(:forward).")
         _fx = nothing
     else
         # more runtime sanity checks?
@@ -47,8 +47,8 @@ function DerivativeCache(
     if typeof(epsilon)!=Nothing && typeof(x)<:StridedArray && typeof(fx)<:Union{Nothing,StridedArray} && 1==2
         warn("StridedArrays don't benefit from pre-allocating epsilon.")
         _epsilon = nothing
-    elseif typeof(epsilon)!=Nothing && fdtype==Val{:complex}
-        warn("Val{:complex} makes the epsilon array redundant.")
+    elseif typeof(epsilon)!=Nothing && fdtype==:complex
+        warn("Val(:complex) makes the epsilon array redundant.")
         _epsilon = nothing
     else
         if typeof(epsilon)==Nothing || eltype(epsilon)!=real(eltype(x))
@@ -65,25 +65,25 @@ Compute the derivative df of a scalar-valued map f at a collection of points x.
 function finite_difference_derivative(
     f,
     x          :: AbstractArray{<:Number},
-    fdtype     :: Type{T1} = Val{:central},
-    returntype :: Type{T2} = eltype(x),      # return type of f
+               :: Val{fdtype} = Val{:central}(),
+    returntype :: Type{T1} = eltype(x),      # return type of f
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing) where {T1,T2}
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing) where {fdtype,T1}
 
     df = zeros(returntype, size(x))
-    finite_difference_derivative!(df, f, x, fdtype, returntype, fx, epsilon)
+    finite_difference_derivative!(df, f, x, Val{fdtype}(), returntype, fx, epsilon)
 end
 
 function finite_difference_derivative!(
     df         :: AbstractArray{<:Number},
     f,
     x          :: AbstractArray{<:Number},
-    fdtype     :: Type{T1} = Val{:central},
-    returntype :: Type{T2} = eltype(x),
+               :: Val{fdtype} = Val{:central}(),
+    returntype :: Type{T1} = eltype(x),
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Nothing,AbstractArray{<:Real}}   = nothing) where {T1,T2}
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}}   = nothing) where {fdtype,T1}
 
-    cache = DerivativeCache(x, fx, epsilon, fdtype, returntype)
+    cache = DerivativeCache(x, fx, epsilon, Val{fdtype}(), returntype)
     finite_difference_derivative!(df, f, x, cache)
 end
 
@@ -95,15 +95,15 @@ function finite_difference_derivative!(df::AbstractArray{<:Number}, f, x::Abstra
         epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
         @. epsilon = compute_epsilon(fdtype, x, epsilon_factor)
     end
-    if fdtype == Val{:forward}
+    if fdtype == :forward
         if typeof(fx) == Nothing
             @. df = (f(x+epsilon) - f(x)) / epsilon
         else
             @. df = (f(x+epsilon) - fx) / epsilon
         end
-    elseif fdtype == Val{:central}
+    elseif fdtype == :central
         @. df = (f(x+epsilon) - f(x-epsilon)) / (2 * epsilon)
-    elseif fdtype == Val{:complex} && returntype<:Real
+    elseif fdtype == :complex && returntype<:Real
         epsilon_complex = eps(eltype(x))
         @. df = imag(f(x+im*epsilon_complex)) / epsilon_complex
     else
@@ -120,11 +120,11 @@ is that here we can compute the epsilon one by one in local variables and aNothi
 function finite_difference_derivative!(df::StridedArray, f, x::StridedArray,
     cache::DerivativeCache{T1,T2,fdtype,returntype}) where {T1,T2,fdtype,returntype}
 
-    epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
-    if fdtype == Val{:forward}
+    epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
+    if fdtype == :forward
         fx = cache.fx
         @inbounds for i ∈ eachindex(x)
-            epsilon = compute_epsilon(Val{:forward}, x[i], epsilon_factor)
+            epsilon = compute_epsilon(Val{:forward}(), x[i], epsilon_factor)
             x_plus = x[i] + epsilon
             if typeof(fx) == Nothing
                 df[i] = (f(x_plus) - f(x[i])) / epsilon
@@ -132,14 +132,14 @@ function finite_difference_derivative!(df::StridedArray, f, x::StridedArray,
                 df[i] = (f(x_plus) - fx[i]) / epsilon
             end
         end
-    elseif fdtype == Val{:central}
+    elseif fdtype == :central
         @inbounds for i ∈ eachindex(x)
-            epsilon = compute_epsilon(Val{:central}, x[i], epsilon_factor)
+            epsilon = compute_epsilon(Val{:central}(), x[i], epsilon_factor)
             epsilon_double_inv = one(typeof(epsilon)) / (2*epsilon)
             x_plus, x_minus = x[i]+epsilon, x[i]-epsilon
             df[i] = (f(x_plus) - f(x_minus)) * epsilon_double_inv
         end
-    elseif fdtype == Val{:complex}
+    elseif fdtype == :complex
         epsilon_complex = eps(eltype(x))
         @inbounds for i ∈ eachindex(x)
             df[i] = imag(f(x[i]+im*epsilon_complex)) / epsilon_complex

--- a/src/finitediff.jl
+++ b/src/finitediff.jl
@@ -14,7 +14,7 @@ end
     eps_cbrt * max(one(real(T)), abs(x))
 end
 
-@inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Void,T}=nothing) where T<:Real
+@inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Nothing,T}=nothing) where T<:Real
     eps(T)
 end
 

--- a/src/finitediff.jl
+++ b/src/finitediff.jl
@@ -6,22 +6,22 @@ Very heavily inspired by Calculus.jl, but with an emphasis on performance and Di
 Compute the finite difference interval epsilon.
 Reference: Numerical Recipes, chapter 5.7.
 =#
-@inline function compute_epsilon(::Type{Val{:forward}}, x::T, eps_sqrt=sqrt(eps(real(T)))) where T<:Number
+@inline function compute_epsilon(::Val{:forward}, x::T, eps_sqrt=sqrt(eps(real(T)))) where T<:Number
     eps_sqrt * max(one(real(T)), abs(x))
 end
 
-@inline function compute_epsilon(::Type{Val{:central}}, x::T, eps_cbrt=cbrt(eps(real(T)))) where T<:Number
+@inline function compute_epsilon(::Val{:central}, x::T, eps_cbrt=cbrt(eps(real(T)))) where T<:Number
     eps_cbrt * max(one(real(T)), abs(x))
 end
 
-@inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Nothing,T}=nothing) where T<:Real
+@inline function compute_epsilon(::Val{:complex}, x::T, ::Union{Nothing,T}=nothing) where T<:Real
     eps(T)
 end
 
-@inline function compute_epsilon_factor(fdtype::DataType, ::Type{T}) where T<:Number
-    if fdtype==Val{:forward}
+@inline function compute_epsilon_factor(::Val{fdtype}, ::Type{T}) where {fdtype, T<:Number}
+    if fdtype==:forward
         return sqrt(eps(real(T)))
-    elseif fdtype==Val{:central}
+    elseif fdtype==:central
         return cbrt(eps(real(T)))
     else
         return one(real(T))
@@ -30,9 +30,9 @@ end
 
 function fdtype_error(funtype::Type{T}=Float64) where T
     if funtype<:Real
-        error("Unrecognized fdtype: valid values are Val{:forward}, Val{:central} and Val{:complex}.")
+        error("Unrecognized fdtype: valid values are Val(:forward), Val(:central) and Val(:complex).")
     elseif funtype<:Complex
-        error("Unrecognized fdtype: valid values are Val{:forward} or Val{:central}.")
+        error("Unrecognized fdtype: valid values are Val(:forward) or Val(:central).")
     else
         error("Unrecognized returntype: should be a subtype of Real or Complex.")
     end

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -44,20 +44,20 @@ function GradientCache(
         end
     end
 
-    GradientCache{Void,typeof(_c1),typeof(_c2),fdtype,
+    GradientCache{Nothing,typeof(_c1),typeof(_c2),fdtype,
                   returntype,inplace}(nothing,_c1,_c2)
 
 end
 
 function GradientCache(
-    c1         :: Union{Void,AbstractArray{<:Number}},
-    c2         :: Union{Void,AbstractArray{<:Number}},
-    fx         :: Union{Void,<:Number,AbstractArray{<:Number}} = nothing,
+    c1         :: Union{Nothing,AbstractArray{<:Number}},
+    c2         :: Union{Nothing,AbstractArray{<:Number}},
+    fx         :: Union{Nothing,<:Number,AbstractArray{<:Number}} = nothing,
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(df),
     inplace    :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
 
-    if fdtype!=Val{:forward} && typeof(fx)!=Void
+    if fdtype!=Val{:forward} && typeof(fx)!=Nothing
         warn("Pre-computed function values are only useful for fdtype == Val{:forward}.")
         _fx = nothing
     else
@@ -75,7 +75,7 @@ function GradientCache(
                 else
                     _c1 = nothing
                     _c2 = nothing
-                    if typeof(c1)!=Void || typeof(c2)!=Void
+                    if typeof(c1)!=Nothing || typeof(c2)!=Nothing
                         warn("For StridedVectors, neither c1 nor c2 are necessary.")
                     end
                 end
@@ -107,15 +107,15 @@ end
 
 function finite_difference_gradient(f, x, fdtype::Type{T1}=Val{:central},
     returntype::Type{T2}=eltype(x), inplace::Type{Val{T3}}=Val{true},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing,
-    c1::Union{Void,AbstractArray{<:Number}}=nothing,
-    c2::Union{Void,AbstractArray{<:Number}}=nothing) where {T1,T2,T3}
+    fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c2::Union{Nothing,AbstractArray{<:Number}}=nothing) where {T1,T2,T3}
 
     if typeof(x) <: AbstractArray
         df = zeros(returntype, size(x))
     else
         if inplace == Val{true}
-            if typeof(fx)==Void && typeof(c1)==Void && typeof(c2)==Void
+            if typeof(fx)==Nothing && typeof(c1)==Nothing && typeof(c2)==Nothing
                 error("In the scalar->vector in-place map case, at least one of fx, c1 or c2 must be provided, otherwise we cannot infer the return size.")
             else
                 if     c1 != nothing    df = similar(c1)
@@ -133,9 +133,9 @@ end
 
 function finite_difference_gradient!(df, f, x, fdtype::Type{T1}=Val{:central},
     returntype::Type{T2}=eltype(df), inplace::Type{Val{T3}}=Val{true},
-    fx::Union{Void,AbstractArray{<:Number}}=nothing,
-    c1::Union{Void,AbstractArray{<:Number}}=nothing,
-    c2::Union{Void,AbstractArray{<:Number}}=nothing,
+    fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c2::Union{Nothing,AbstractArray{<:Number}}=nothing,
     ) where {T1,T2,T3}
 
     cache = GradientCache(df,x,fdtype,returntype,inplace)
@@ -172,7 +172,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
             epsilon = c2[i]
             c1_old = c1[i]
             c1[i] += epsilon
-            if typeof(fx) != Void
+            if typeof(fx) != Nothing
                 dfi = (f(c1) - fx) / epsilon
             else
                 fx0 = f(x)
@@ -182,7 +182,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
             c1[i] = c1_old
             if eltype(df)<:Complex
                 c1[i] += im * epsilon
-                if typeof(fx) != Void
+                if typeof(fx) != Nothing
                     dfi = (f(c1) - fx) / (im*epsilon)
                 else
                     dfi = (f(c1) - fx0) / (im*epsilon)
@@ -212,7 +212,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
     elseif fdtype == Val{:complex} && returntype <: Real
         copy!(c1,x)
         epsilon_complex = eps(real(eltype(x)))
-        # we use c1 here to avoid typing issues with x
+        # we use c1 here to aNothing typing issues with x
         @inbounds for i ∈ eachindex(x)
             c1_old = c1[i]
             c1[i] += im*epsilon_complex
@@ -228,8 +228,8 @@ end
 function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedVector{<:Number},
     cache::GradientCache{T1,T2,T3,fdtype,returntype,inplace}) where {T1,T2,T3,fdtype,returntype,inplace}
 
-    # c1 is x1 if we need a complex copy of x, otherwise Void
-    # c2 is Void
+    # c1 is x1 if we need a complex copy of x, otherwise Nothing
+    # c2 is Nothing
     fx, c1, c2 = cache.fx, cache.c1, cache.c2
     if fdtype != Val{:complex}
         epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
@@ -241,7 +241,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
         for i ∈ eachindex(x)
             epsilon = compute_epsilon(fdtype, x[i], epsilon_factor)
             x_old = x[i]
-            if typeof(fx) != Void
+            if typeof(fx) != Nothing
                 x[i] += epsilon
                 dfi = (f(x) - fx) / epsilon
                 x[i] = x_old
@@ -256,7 +256,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
             if eltype(df)<:Complex
                 if eltype(x)<:Complex
                     x[i] += im * epsilon
-                    if typeof(fx) != Void
+                    if typeof(fx) != Nothing
                         dfi = (f(x) - fx) / (im*epsilon)
                     else
                         dfi = (f(x) - fx0) / (im*epsilon)
@@ -264,7 +264,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
                     x[i] = x_old
                 else
                     c1[i] += im * epsilon
-                    if typeof(fx) != Void
+                    if typeof(fx) != Nothing
                         dfi = (f(c1) - fx) / (im*epsilon)
                     else
                         dfi = (f(c1) - fx0) / (im*epsilon)
@@ -304,7 +304,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
     elseif fdtype==Val{:complex} && returntype<:Real && eltype(df)<:Real && eltype(x)<:Real
         copy!(c1,x)
         epsilon_complex = eps(real(eltype(x)))
-        # we use c1 here to avoid typing issues with x
+        # we use c1 here to aNothing typing issues with x
         @inbounds for i ∈ eachindex(x)
             c1_old = c1[i]
             c1[i] += im*epsilon_complex
@@ -334,7 +334,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Number,
         else
             c1 .= f(x+epsilon)
         end
-        if typeof(fx) != Void
+        if typeof(fx) != Nothing
             @. df = (c1 - fx) / epsilon
         else
             if inplace == Val{true}

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -234,7 +234,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
     if fdtype != :complex
         epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
         if eltype(df)<:Complex && !(eltype(x)<:Complex)
-            copy!(c1,x)
+            copyto!(c1,x)
         end
     end
     if fdtype == :forward
@@ -302,7 +302,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
             end
         end
     elseif fdtype==:complex && returntype<:Real && eltype(df)<:Real && eltype(x)<:Real
-        copy!(c1,x)
+        copyto!(c1,x)
         epsilon_complex = eps(real(eltype(x)))
         # we use c1 here to aNothing typing issues with x
         @inbounds for i ∈ eachindex(x)

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -163,7 +163,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
     # c1 denotes x1, c2 is epsilon
     fx, c1, c2 = cache.fx, cache.c1, cache.c2
     if fdtype != :complex
-        epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
+        epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
         @. c2 = compute_epsilon(Val{fdtype}(), x, epsilon_factor)
         copy!(c1,x)
     end

--- a/src/gradients.jl
+++ b/src/gradients.jl
@@ -7,12 +7,12 @@ end
 function GradientCache(
     df         :: Union{<:Number,AbstractArray{<:Number}},
     x          :: Union{<:Number, AbstractArray{<:Number}},
-    fdtype     :: Type{T1} = Val{:central},
-    returntype :: Type{T2} = eltype(df),
-    inplace    :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+               :: Val{fdtype} = Val{:central}(),
+    returntype :: Type{T1} = eltype(df),
+               :: Val{inplace} = Val{true}()) where {T1,fdtype,inplace}
 
     if typeof(x)<:AbstractArray # the vector->scalar case
-        if fdtype!=Val{:complex} # complex-mode FD only needs one cache, for x+eps*im
+        if fdtype!=:complex # complex-mode FD only needs one cache, for x+eps*im
             if typeof(x)<:StridedVector
                 if eltype(df)<:Complex && !(eltype(x)<:Complex)
                     _c1 = zeros(Complex{eltype(x)}, size(x))
@@ -29,13 +29,13 @@ function GradientCache(
             if !(returntype<:Real)
                 fdtype_error(returntype)
             else
-                _c1 = x + 0*im
+                _c1 = x .+ 0*im
                 _c2 = nothing
             end
         end
     else # the scalar->vector case
         # need cache arrays for fx1 and fx2, except in complex mode, which needs one complex array
-        if fdtype != Val{:complex}
+        if fdtype != :complex
             _c1 = similar(df)
             _c2 = similar(df)
         else
@@ -49,15 +49,15 @@ function GradientCache(
 
 end
 
+# Needs serious review!
 function GradientCache(
     c1         :: Union{Nothing,AbstractArray{<:Number}},
     c2         :: Union{Nothing,AbstractArray{<:Number}},
     fx         :: Union{Nothing,<:Number,AbstractArray{<:Number}} = nothing,
-    fdtype     :: Type{T1} = Val{:central},
-    returntype :: Type{T2} = eltype(df),
-    inplace    :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
-
-    if fdtype!=Val{:forward} && typeof(fx)!=Nothing
+               :: Val{fdtype} = Val{:central}(),
+    returntype :: Type{T1} = eltype(c1),
+               :: Val{inplace} = Val{true}()) where {T1,fdtype,inplace}
+    if fdtype!=:forward && typeof(fx)!=Nothing
         warn("Pre-computed function values are only useful for fdtype == Val{:forward}.")
         _fx = nothing
     else
@@ -65,12 +65,12 @@ function GradientCache(
         _fx = fx
     end
 
-    if typeof(x)<:AbstractArray # the vector->scalar case
+    if typeof(fx)<:AbstractArray # the vector->scalar case
         # need cache arrays for x1 (c1) and epsilon (c2) (both only if non-StridedArray)
-        if fdtype!=Val{:complex} # complex-mode FD only needs one cache, for x+eps*im
-            if typeof(x)<:StridedVector
-                if eltype(df)<:Complex && !(eltype(x)<:Complex)
-                    _c1 = zeros(Complex{eltype(x)}, size(x))
+        if fdtype!=:complex # complex-mode FD only needs one cache, for x+eps*im
+            if typeof(fx)<:StridedVector
+                if eltype(c1)<:Complex && !(eltype(fx)<:Complex)
+                    _c1 = zeros(Complex{eltype(fx)}, size(fx))
                     _c2 = nothing
                 else
                     _c1 = nothing
@@ -94,7 +94,7 @@ function GradientCache(
 
     else # the scalar->vector case
         # need cache arrays for fx1 and fx2, except in complex mode, which needs one complex array
-        if fdtype != Val{:complex}
+        if fdtype != :complex
             _c1 = c1
             _c2 = c2
         else
@@ -105,16 +105,16 @@ function GradientCache(
     GradientCache{typeof(_fx),typeof(_c1),typeof(_c2),fdtype,returntype,inplace}(_fx,_c1,_c2)
 end
 
-function finite_difference_gradient(f, x, fdtype::Type{T1}=Val{:central},
-    returntype::Type{T2}=eltype(x), inplace::Type{Val{T3}}=Val{true},
+function finite_difference_gradient(f, x, ::Val{fdtype}=Val{:central}(),
+    returntype::Type{T1}=eltype(x), ::Val{inplace}=Val{true}(),
     fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
     c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
-    c2::Union{Nothing,AbstractArray{<:Number}}=nothing) where {T1,T2,T3}
+    c2::Union{Nothing,AbstractArray{<:Number}}=nothing) where {T1,fdtype,inplace}
 
     if typeof(x) <: AbstractArray
         df = zeros(returntype, size(x))
     else
-        if inplace == Val{true}
+        if inplace == true
             if typeof(fx)==Nothing && typeof(c1)==Nothing && typeof(c2)==Nothing
                 error("In the scalar->vector in-place map case, at least one of fx, c1 or c2 must be provided, otherwise we cannot infer the return size.")
             else
@@ -127,18 +127,18 @@ function finite_difference_gradient(f, x, fdtype::Type{T1}=Val{:central},
             df = similar(f(x))
         end
     end
-    cache = GradientCache(df,x,fdtype,returntype,inplace)
+    cache = GradientCache(df,x,Val{fdtype}(),returntype,Val{inplace}())
     finite_difference_gradient!(df,f,x,cache)
 end
 
-function finite_difference_gradient!(df, f, x, fdtype::Type{T1}=Val{:central},
-    returntype::Type{T2}=eltype(df), inplace::Type{Val{T3}}=Val{true},
+function finite_difference_gradient!(df, f, x, ::Val{fdtype}=Val{:central}(),
+    returntype::Type{T1}=eltype(x), ::Val{inplace}=Val{true}(),
     fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
     c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
     c2::Union{Nothing,AbstractArray{<:Number}}=nothing,
-    ) where {T1,T2,T3}
+    ) where {T1,fdtype,inplace}
 
-    cache = GradientCache(df,x,fdtype,returntype,inplace)
+    cache = GradientCache(df,x,Val{fdtype}(),returntype,Val{inplace}())
     finite_difference_gradient!(df,f,x,cache)
 end
 
@@ -162,12 +162,12 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
     # NOTE: in this case epsilon is a vector, we need two arrays for epsilon and x1
     # c1 denotes x1, c2 is epsilon
     fx, c1, c2 = cache.fx, cache.c1, cache.c2
-    if fdtype != Val{:complex}
+    if fdtype != :complex
         epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
-        @. c2 = compute_epsilon(fdtype, x, epsilon_factor)
+        @. c2 = compute_epsilon(Val{fdtype}(), x, epsilon_factor)
         copy!(c1,x)
     end
-    if fdtype == Val{:forward}
+    if fdtype == :forward
         @inbounds for i ∈ eachindex(x)
             epsilon = c2[i]
             c1_old = c1[i]
@@ -191,7 +191,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
                 df[i] -= im * imag(dfi)
             end
         end
-    elseif fdtype == Val{:central}
+    elseif fdtype == :central
         @inbounds for i ∈ eachindex(x)
             epsilon = c2[i]
             c1_old = c1[i]
@@ -209,7 +209,7 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Abstract
                 x[i] = x_old
             end
         end
-    elseif fdtype == Val{:complex} && returntype <: Real
+    elseif fdtype == :complex && returntype <: Real
         copy!(c1,x)
         epsilon_complex = eps(real(eltype(x)))
         # we use c1 here to aNothing typing issues with x
@@ -231,15 +231,15 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
     # c1 is x1 if we need a complex copy of x, otherwise Nothing
     # c2 is Nothing
     fx, c1, c2 = cache.fx, cache.c1, cache.c2
-    if fdtype != Val{:complex}
-        epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
+    if fdtype != :complex
+        epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
         if eltype(df)<:Complex && !(eltype(x)<:Complex)
             copy!(c1,x)
         end
     end
-    if fdtype == Val{:forward}
+    if fdtype == :forward
         for i ∈ eachindex(x)
-            epsilon = compute_epsilon(fdtype, x[i], epsilon_factor)
+            epsilon = compute_epsilon(Val{fdtype}(), x[i], epsilon_factor)
             x_old = x[i]
             if typeof(fx) != Nothing
                 x[i] += epsilon
@@ -274,9 +274,9 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
                 df[i] -= im * imag(dfi)
             end
         end
-    elseif fdtype == Val{:central}
+    elseif fdtype == :central
         @inbounds for i ∈ eachindex(x)
-            epsilon = compute_epsilon(fdtype, x[i], epsilon_factor)
+            epsilon = compute_epsilon(Val{fdtype}(), x[i], epsilon_factor)
             x_old = x[i]
             x[i] += epsilon
             dfi = f(x)
@@ -301,7 +301,7 @@ function finite_difference_gradient!(df::StridedVector{<:Number}, f, x::StridedV
                 df[i] -= im*imag(dfi / (2*im*epsilon))
             end
         end
-    elseif fdtype==Val{:complex} && returntype<:Real && eltype(df)<:Real && eltype(x)<:Real
+    elseif fdtype==:complex && returntype<:Real && eltype(df)<:Real && eltype(x)<:Real
         copy!(c1,x)
         epsilon_complex = eps(real(eltype(x)))
         # we use c1 here to aNothing typing issues with x
@@ -326,10 +326,10 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Number,
     # c1 denotes fx1, c2 is fx2, sizes guaranteed by the cache constructor
     fx, c1, c2 = cache.fx, cache.c1, cache.c2
 
-    if fdtype == Val{:forward}
-        epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
-        epsilon = compute_epsilon(Val{:forward}, x, epsilon_factor)
-        if inplace == Val{true}
+    if fdtype == :forward
+        epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
+        epsilon = compute_epsilon(Val{:forward}(), x, epsilon_factor)
+        if inplace == true
             f(c1, x+epsilon)
         else
             c1 .= f(x+epsilon)
@@ -337,17 +337,17 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Number,
         if typeof(fx) != Nothing
             @. df = (c1 - fx) / epsilon
         else
-            if inplace == Val{true}
+            if inplace == true
                 f(c2, x)
             else
                 c2 .= f(x)
             end
             @. df = (c1 - c2) / epsilon
         end
-    elseif fdtype == Val{:central}
-        epsilon_factor = compute_epsilon_factor(fdtype, eltype(x))
-        epsilon = compute_epsilon(Val{:central}, x, epsilon_factor)
-        if inplace == Val{true}
+    elseif fdtype == :central
+        epsilon_factor = compute_epsilon_factor(Val{fdtype}(), eltype(x))
+        epsilon = compute_epsilon(Val{:central}(), x, epsilon_factor)
+        if inplace == true
             f(c1, x+epsilon)
             f(c2, x-epsilon)
         else
@@ -355,9 +355,9 @@ function finite_difference_gradient!(df::AbstractArray{<:Number}, f, x::Number,
             c2 .= f(x-epsilon)
         end
         @. df = (c1 - c2) / (2*epsilon)
-    elseif fdtype == Val{:complex} && returntype <: Real
+    elseif fdtype == :complex && returntype <: Real
         epsilon_complex = eps(real(eltype(x)))
-        if inplace == Val{true}
+        if inplace == true
             f(c1, x+im*epsilon_complex)
         else
             c1 .= f(x+im*epsilon_complex)

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -59,19 +59,19 @@ function JacobianCache(
     fx ,
     fx1,
                 :: Val{fdtype} = Val{:central}(),
-    returntype  :: Type{T1} = eltype(x),
+    returntype  :: Type{T1} = eltype(x1),
                 :: Val{inplace} = Val{true}()) where {T1,fdtype,inplace}
 
     if fdtype==:complex
         !(returntype<:Real) && fdtype_error(returntype)
 
         if eltype(fx) <: Real
-            _fx = zeros(Complex{eltype(x)}, size(fx))
+            _fx = zeros(Complex{eltype(x1)}, size(fx))
         else
             _fx = fx
         end
         if eltype(x1) <: Real
-            _x1 = zeros(Complex{eltype(x)}, size(x1))
+            _x1 = zeros(Complex{eltype(x1)}, size(x1))
         else
             _x1 = x1
         end
@@ -105,7 +105,7 @@ function finite_difference_jacobian!(J::AbstractMatrix{<:Number},
 
     m, n = size(J)
     x1, fx, fx1 = cache.x1, cache.fx, cache.fx1
-    copy!(x1, x)
+    copyto!(x1, x)
     vfx = vec(fx)
     if fdtype == :forward
         vfx1 = vec(fx1)

--- a/src/old_val_api.jl
+++ b/src/old_val_api.jl
@@ -1,0 +1,151 @@
+
+function finite_difference_derivative(f, x::T, fdtype::Type{Val{T1}},# = Val{:central}
+    returntype::Type{T2}=eltype(x), f_x::Union{Nothing,T}=nothing) where {T<:Number,T1,T2}
+    
+    finite_difference_derivative(f, x, Val{T1}(), returntype, f_x)
+end
+
+
+function DerivativeCache(
+    x          :: AbstractArray{<:Number},
+    fx         :: Union{Nothing,AbstractArray{<:Number}},# = nothing,
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}},# = nothing,
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(x)) where {T1,T2}
+
+    DerivativeCache(x, fx, epsilon, Val{T1}(), returntype)
+
+end
+
+
+function finite_difference_derivative(
+    f,
+    x          :: AbstractArray{<:Number},
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(x),      # return type of f
+    fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
+    epsilon :: Union{Nothing,AbstractArray{<:Real}} = nothing) where {T1,T2}
+
+    finite_difference_derivative(f, x, Val{T1}(), returntype, fx, epsilon)
+
+end
+
+
+
+
+function finite_difference_derivative!(
+    df         :: AbstractArray{<:Number},
+    f,
+    x          :: AbstractArray{<:Number},
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(x),
+    fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
+    epsilon :: Union{Nothing,AbstractArray{<:Real}} = nothing) where {T1,T2}
+    
+    finite_difference_derivative!(df, f, x, Val{T1}(), returntype, fx, epsilon)
+
+end
+
+
+
+
+
+function GradientCache(
+    df         :: Union{<:Number,AbstractArray{<:Number}},
+    x          :: Union{<:Number, AbstractArray{<:Number}},
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(df),
+    inplace    :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+
+    GradientCache(df, x, Val{T1}(), returntype, Val{T3}())
+
+end
+
+
+
+
+
+function GradientCache(
+    c1         :: Union{Nothing,AbstractArray{<:Number}},
+    c2         :: Union{Nothing,AbstractArray{<:Number}},
+    fx         :: Union{Nothing,<:Number,AbstractArray{<:Number}},# = nothing,
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(c1),
+    inplace    :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+
+
+GradientCache(c1, c2, fx, Val{T1}(), returntype, Val{T3}())
+
+
+end
+
+function finite_difference_gradient(f, x, fdtype::Type{Val{T1}},# =Val{:central},
+    returntype::Type{T2}=eltype(x), inplace::Type{Val{T3}}=Val{true},
+    fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c2::Union{Nothing,AbstractArray{<:Number}}=nothing) where {T1,T2,T3}
+
+    finite_difference_gradient(f, x, Val{T1}(), returntype, Val{T3}(), fx, c1, c2)
+
+end
+
+
+
+
+
+function finite_difference_gradient!(df, f, x, fdtype::Type{Val{T1}},# =Val{:central},
+    returntype::Type{T2}=eltype(df), inplace::Type{Val{T3}}=Val{true},
+    fx::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c1::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    c2::Union{Nothing,AbstractArray{<:Number}}=nothing,
+    ) where {T1,T2,T3}
+    
+    finite_difference_gradient!(df, f, x, Val{T1}(), returntype, Val{T3}(), fx, c1, c2)
+
+end
+
+function JacobianCache(
+    x,
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(x),
+    inplace :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+
+    JacobianCache(x, Val{T1}(), returntype, Val{T3}())
+
+end
+
+
+function JacobianCache(
+    x ,
+    fx,
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(x),
+    inplace :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+
+    JacobianCache(x, fx, Val{T1}(), returntype, Val{T3}())
+
+end
+
+
+function JacobianCache(
+    x1 ,
+    fx ,
+    fx1,
+    fdtype     :: Type{Val{T1}},# = Val{:central},
+    returntype :: Type{T2} = eltype(fx),
+    inplace :: Type{Val{T3}} = Val{true}) where {T1,T2,T3}
+
+    JacobianCache( x1, fx, fx1, Val{T1}(), returntype, Val{T3}())
+
+end
+
+
+
+function finite_difference_jacobian(f, x::AbstractArray{<:Number},
+    fdtype     :: Type{Val{T1}},# =Val{:central},
+    returntype :: Type{T2}=eltype(x),
+    inplace    :: Type{Val{T3}}=Val{true}) where {T1,T2,T3}
+
+    finite_difference_jacobian(f, x, Val{T1}(), returntype, Val{T3}())
+
+end

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -17,31 +17,31 @@ complex_cache = DiffEqDiffTools.DerivativeCache(x, nothing, nothing, Val{:comple
 err_func(a,b) = maximum(abs.(a-b))
 
 @time @testset "Derivative single point f : R -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:forward}()), √2/2) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:central}()), √2/2) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:complex}()), √2/2) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:forward}()), √2/2)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:central}()), √2/2)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:complex}()), √2/2)) < 1e-15
 end
 
 @time @testset "Derivative StridedArray f : R -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}()), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}()), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}()), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}()), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}()), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}()), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}()), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}()), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, central_cache), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, complex_cache), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, complex_cache), df_ref)) < 1e-15
 end
 
 x = x + im*x
@@ -54,31 +54,31 @@ forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}())
 central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}())
 
 @time @testset "Derivative single point f : C -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:forward}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:central}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-7
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:forward}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4))) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:central}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4))) < 1e-7
 end
 
 @time @testset "Derivative StridedArray f : C -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}()), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}()), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}()), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}()), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y, epsilon), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x)), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x)), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x)), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x)), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y, epsilon), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref)) < 1e-6
 end
 
 x = collect(Compat.range(-2π, stop=2π, length=100))
@@ -91,31 +91,31 @@ forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}(), 
 central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}(), eltype(df))
 
 @time @testset "Derivative single point f : R -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:forward}(), Complex{Float64}), cos(π/4)-im*sin(π/4)) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:central}(), Complex{Float64}), cos(π/4)-im*sin(π/4)) < 1e-7
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:forward}(), Complex{Float64}), cos(π/4)-im*sin(π/4))) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:central}(), Complex{Float64}), cos(π/4)-im*sin(π/4))) < 1e-7
 end
 
 @time @testset "Derivative StridedArray f : R -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref)) < 1e-6
 end
 
 #=
@@ -169,17 +169,17 @@ central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
 
 @time @testset "Gradient of f:vector->scalar real-valued tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}()), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}()), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref)) < 1e-15
 end
 
 f(x) = 2x[1] + im*2x[1] + x[2]^2
@@ -191,14 +191,14 @@ forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f : C^N -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
 end
 
 f(x) = sum(abs2, x)
@@ -210,14 +210,14 @@ forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f : C^N -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
 end
 
 f(x) = 2*x[1] + im*x[2]^2
@@ -229,14 +229,14 @@ forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}(),eltype(df))
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}(),eltype(df))
 
 @time @testset "Gradient of f : R^N -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(df)), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(df)), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(df)), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(df)), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}(), eltype(df)), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}(), eltype(df)), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}(), eltype(df)), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}(), eltype(df)), df_ref)) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
 end
 
 f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
@@ -252,17 +252,17 @@ complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
 
 @time @testset "Gradient of f:scalar->vector real-valued tests" begin
     @test_broken err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}(), eltype(x), Val{true}(), fx), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}(), eltype(x), Val{true}(), fx), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref)) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref) < 1e-15
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref)) < 1e-15
 end
 
 f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
@@ -275,14 +275,14 @@ forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f:vector->scalar complex-valued tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref) < 1e-7
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref)) < 1e-7
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-7
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref)) < 1e-7
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-7
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-7
 end
 
 # Jacobian tests
@@ -302,10 +302,10 @@ central_cache = DiffEqDiffTools.JacobianCache(x)
 complex_cache = DiffEqDiffTools.JacobianCache(x,Val{:complex}())
 
 @time @testset "Jacobian StridedArray real-valued tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, complex_cache), J_ref) < 1e-14
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, complex_cache), J_ref)) < 1e-14
 end
 
 function f(fvec,x)
@@ -324,7 +324,7 @@ forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward}())
 central_cache = DiffEqDiffTools.JacobianCache(x)
 
 @time @testset "Jacobian StridedArray f : C^N -> C^N tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref)) < 1e-8
 end

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -1,13 +1,14 @@
-using DiffEqDiffTools, Base.Test
+using DiffEqDiffTools
+using Compat, Compat.Test, Compat.LinearAlgebra
 
 # TODO: add tests for GPUArrays
 # TODO: add tests for DEDataArrays
 
 # Derivative tests
-x = collect(linspace(-2π, 2π, 100))
+x = collect(Compat.range(-2π, stop=2π, length=100))
 y = sin.(x)
-df = zeros(100)
-epsilon = zeros(100)
+df = fill(0.0,100)
+epsilon = fill(0.0,100)
 df_ref = cos.(x)
 forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}())
 central_cache = DiffEqDiffTools.DerivativeCache(x, nothing, epsilon, Val{:central}())
@@ -46,7 +47,7 @@ end
 x = x + im*x
 f(x) = sin(x) + cos(x)
 y = f.(x)
-df = zeros(x)
+df = zero(x)
 epsilon = similar(real(x))
 df_ref = cos.(x) - sin.(x)
 forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}())
@@ -80,10 +81,10 @@ end
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
 end
 
-x = collect(linspace(-2π, 2π, 100))
+x = collect(Compat.range(-2π, stop=2π, length=100))
 f(x) = sin(x) + im*cos(x)
 y = f.(x)
-df = zeros(Complex{eltype(x)}, size(x))
+df = fill(zero(Complex{eltype(x)}), size(x))
 epsilon = similar(real(x))
 df_ref = cos.(x) - im*sin.(x)
 forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}(), eltype(df))
@@ -121,7 +122,7 @@ end
 x = x + im*x
 f(x) = abs2(x)
 y = f.(x)
-df = zeros(eltype(x), size(x))
+df = zero(eltype(x), size(x))
 epsilon = similar(real(x))
 df_ref = 2*conj.(x)
 forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}, eltype(df))
@@ -161,7 +162,7 @@ end
 f(x) = 2x[1] + x[2]^2
 x = rand(2)
 fx = f(x)
-df = zeros(2)
+df = fill(0.0, 2)
 df_ref = [2., 2*x[2]]
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
@@ -184,7 +185,7 @@ end
 f(x) = 2x[1] + im*2x[1] + x[2]^2
 x = x + im*x
 fx = f(x)
-df = zeros(x)
+df = zero(x)
 df_ref = conj([2.0+2.0*im, 2.0*x[2]])
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
@@ -203,7 +204,7 @@ end
 f(x) = sum(abs2, x)
 x = ones(2) * (1 + im)
 fx = f(x)
-df = zeros(x)
+df = zero(x)
 df_ref = 2*x
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
@@ -222,7 +223,7 @@ end
 f(x) = 2*x[1] + im*x[2]^2
 x = ones(2)
 fx = f(x)
-df = zeros(eltype(fx), size(x))
+df = fill(zero(eltype(fx)), size(x))
 df_ref = [2.0, -im*2*x[2]]
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}(),eltype(df))
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}(),eltype(df))
@@ -240,9 +241,9 @@ end
 
 f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
 x = 2π * rand()
-fx = zeros(2)
+fx = fill(0.0,2)
 f(fx,x)
-df = zeros(2)
+df = fill(0.0,2)
 df_ref = [cos(x), -sin(x)]
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
@@ -266,9 +267,9 @@ end
 
 f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
 x = (2π * rand()) * (1 + im)
-fx = zeros(typeof(x), 2)
+fx = fill(zero(typeof(x)), 2)
 f(fx,x)
-df = zeros(fx)
+df = zero(fx)
 df_ref = [cos(x), -sin(x)]
 forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
 central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
@@ -292,10 +293,10 @@ end
 x = rand(2); y = rand(2)
 f(y,x)
 J_ref = [[-7+x[2]^3 3*(3+x[1])*x[2]^2]; [exp(x[1])*x[2]*cos(1-exp(x[1])*x[2]) exp(x[1])*cos(1-exp(x[1])*x[2])]]
-J = zeros(J_ref)
-df = zeros(x)
+J = zero(J_ref)
+df = zero(x)
 df_ref = diag(J_ref)
-epsilon = zeros(x)
+epsilon = zero(x)
 forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward}())
 central_cache = DiffEqDiffTools.JacobianCache(x)
 complex_cache = DiffEqDiffTools.JacobianCache(x,Val{:complex}())
@@ -315,10 +316,10 @@ x = rand(2) + im*rand(2)
 y = similar(x)
 f(y,x)
 J_ref = [[im*(-7+x[2]^3) 3*(3+im*x[1])*x[2]^2]; [exp(x[1])*x[2]*cos(1-exp(x[1])*x[2]) exp(x[1])*cos(1-exp(x[1])*x[2])]]
-J = zeros(J_ref)
-df = zeros(x)
+J = zero(J_ref)
+df = zero(x)
 df_ref = diag(J_ref)
-epsilon = zeros(real.(x))
+epsilon = zero(real.(x))
 forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward}())
 central_cache = DiffEqDiffTools.JacobianCache(x)
 

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -9,34 +9,34 @@ y = sin.(x)
 df = zeros(100)
 epsilon = zeros(100)
 df_ref = cos.(x)
-forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward})
-central_cache = DiffEqDiffTools.DerivativeCache(x, nothing, epsilon, Val{:central})
-complex_cache = DiffEqDiffTools.DerivativeCache(x, nothing, nothing, Val{:complex})
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}())
+central_cache = DiffEqDiffTools.DerivativeCache(x, nothing, epsilon, Val{:central}())
+complex_cache = DiffEqDiffTools.DerivativeCache(x, nothing, nothing, Val{:complex}())
 
 err_func(a,b) = maximum(abs.(a-b))
 
 @time @testset "Derivative single point f : R -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:forward}), √2/2) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:central}), √2/2) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:complex}), √2/2) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:forward}()), √2/2) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:central}()), √2/2) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:complex}()), √2/2) < 1e-15
 end
 
 @time @testset "Derivative StridedArray f : R -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}()), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}()), df_ref) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}, eltype(x), y, epsilon), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}, eltype(x), y, epsilon), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}, eltype(x), y, epsilon), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}()), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}()), df_ref) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}, eltype(x), y, epsilon), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}, eltype(x), y, epsilon), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}, eltype(x), y, epsilon), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}(), eltype(x), y, epsilon), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, central_cache), df_ref) < 1e-8
@@ -49,32 +49,32 @@ y = f.(x)
 df = zeros(x)
 epsilon = similar(real(x))
 df_ref = cos.(x) - sin.(x)
-forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward})
-central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central})
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}())
+central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}())
 
 @time @testset "Derivative single point f : C -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:forward}, Val{:Complex}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:central}, Val{:Complex}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:forward}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:central}(), Complex{Float64}), cos(π/4+im*π/4)-sin(π/4+im*π/4)) < 1e-7
 end
 
 @time @testset "Derivative StridedArray f : C -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}()), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}()), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, eltype(x), y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, eltype(x), y), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, eltype(x), y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, eltype(x), y, epsilon), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x)), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x)), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x)), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x)), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x), y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x), y), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x), y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x), y, epsilon), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), eltype(x), y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), eltype(x), y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
@@ -86,32 +86,32 @@ y = f.(x)
 df = zeros(Complex{eltype(x)}, size(x))
 epsilon = similar(real(x))
 df_ref = cos.(x) - im*sin.(x)
-forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}, eltype(df))
-central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}, eltype(df))
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}(), eltype(df))
+central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}(), eltype(df))
 
 @time @testset "Derivative single point f : R -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:forward}, Val{:Complex}), cos(π/4)-im*sin(π/4)) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:central}, Val{:Complex}), cos(π/4)-im*sin(π/4)) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:forward}(), Complex{Float64}), cos(π/4)-im*sin(π/4)) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:central}(), Complex{Float64}), cos(π/4)-im*sin(π/4)) < 1e-7
 end
 
 @time @testset "Derivative StridedArray f : R -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y), df_ref) < 1e-6
 
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}(), Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
@@ -163,18 +163,18 @@ x = rand(2)
 fx = f(x)
 df = zeros(2)
 df_ref = [2., 2*x[2]]
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
-complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
+complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
 
 @time @testset "Gradient of f:vector->scalar real-valued tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}()), df_ref) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
@@ -186,15 +186,15 @@ x = x + im*x
 fx = f(x)
 df = zeros(x)
 df_ref = conj([2.0+2.0*im, 2.0*x[2]])
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f : C^N -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
@@ -205,15 +205,15 @@ x = ones(2) * (1 + im)
 fx = f(x)
 df = zeros(x)
 df_ref = 2*x
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f : C^N -> R tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}()), df_ref) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
@@ -224,15 +224,15 @@ x = ones(2)
 fx = f(x)
 df = zeros(eltype(fx), size(x))
 df_ref = [2.0, -im*2*x[2]]
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward},eltype(df))
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central},eltype(df))
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}(),eltype(df))
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}(),eltype(df))
 
 @time @testset "Gradient of f : R^N -> C tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(df)), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(df)), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(df)), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(df)), df_ref) < 1e-8
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, eltype(df)), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}, eltype(df)), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}(), eltype(df)), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}(), eltype(df)), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
@@ -244,20 +244,20 @@ fx = zeros(2)
 f(fx,x)
 df = zeros(2)
 df_ref = [cos(x), -sin(x)]
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
-complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
+complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
 
 
 @time @testset "Gradient of f:scalar->vector real-valued tests" begin
-    @test_broken err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(x), Val{true}, fx), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(x), Val{true}, fx), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}, eltype(x), Val{true}, fx), df_ref) < 1e-15
+    @test_broken err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}(), eltype(x), Val{true}(), fx), df_ref) < 1e-15
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref) < 1e-15
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-8
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}()), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
@@ -270,15 +270,15 @@ fx = zeros(typeof(x), 2)
 f(fx,x)
 df = zeros(fx)
 df_ref = [cos(x), -sin(x)]
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
 
 @time @testset "Gradient of f:vector->scalar complex-valued tests" begin
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(x), Val{true}, fx), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(x), Val{true}, fx), df_ref) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}(), eltype(x), Val{true}(), fx), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}(), eltype(x), Val{true}(), fx), df_ref) < 1e-7
 
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-7
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}()), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}()), df_ref) < 1e-7
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-7
@@ -296,9 +296,9 @@ J = zeros(J_ref)
 df = zeros(x)
 df_ref = diag(J_ref)
 epsilon = zeros(x)
-forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward})
+forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward}())
 central_cache = DiffEqDiffTools.JacobianCache(x)
-complex_cache = DiffEqDiffTools.JacobianCache(x,Val{:complex})
+complex_cache = DiffEqDiffTools.JacobianCache(x,Val{:complex}())
 
 @time @testset "Jacobian StridedArray real-valued tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
@@ -319,7 +319,7 @@ J = zeros(J_ref)
 df = zeros(x)
 df_ref = diag(J_ref)
 epsilon = zeros(real.(x))
-forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward})
+forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward}())
 central_cache = DiffEqDiffTools.JacobianCache(x)
 
 @time @testset "Jacobian StridedArray f : C^N -> C^N tests" begin

--- a/test/old_interface_tests.jl
+++ b/test/old_interface_tests.jl
@@ -1,0 +1,330 @@
+using DiffEqDiffTools
+using Compat, Compat.Test, Compat.LinearAlgebra
+
+# TODO: add tests for GPUArrays
+# TODO: add tests for DEDataArrays
+
+# Derivative tests
+x = collect(Compat.range(-2π, stop=2π, length=100))
+y = sin.(x)
+df = fill(0.0,100)
+epsilon = fill(0.0,100)
+df_ref = cos.(x)
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward})
+central_cache = DiffEqDiffTools.DerivativeCache(x, nothing, epsilon, Val{:central})
+complex_cache = DiffEqDiffTools.DerivativeCache(x, nothing, nothing, Val{:complex})
+
+err_func(a,b) = maximum(abs.(a-b))
+
+@time @testset "Derivative single point f : R -> R tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:forward}), √2/2)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:central}), √2/2)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, π/4, Val{:complex}), √2/2)) < 1e-15
+end
+
+@time @testset "Derivative StridedArray f : R -> R tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:forward}, eltype(x), y, epsilon), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:central}, eltype(x), y, epsilon), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(sin, x, Val{:complex}, eltype(x), y, epsilon), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:forward}, eltype(x), y, epsilon), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:central}, eltype(x), y, epsilon), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, Val{:complex}, eltype(x), y, epsilon), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, sin, x, complex_cache), df_ref)) < 1e-15
+end
+
+x = x + im*x
+f(x) = sin(x) + cos(x)
+y = f.(x)
+df = zero(x)
+epsilon = similar(real(x))
+df_ref = cos.(x) - sin.(x)
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward})
+central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central})
+
+@time @testset "Derivative single point f : C -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:forward}, Val{:Complex}), cos(π/4+im*π/4)-sin(π/4+im*π/4))) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4+im*π/4, Val{:central}, Val{:Complex}), cos(π/4+im*π/4)-sin(π/4+im*π/4))) < 1e-7
+end
+
+@time @testset "Derivative StridedArray f : C -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, eltype(x), y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, eltype(x), y), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, eltype(x), y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, eltype(x), y, epsilon), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x)), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x)), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x), y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x), y), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, eltype(x), y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, eltype(x), y, epsilon), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref)) < 1e-6
+end
+
+x = collect(Compat.range(-2π, stop=2π, length=100))
+f(x) = sin(x) + im*cos(x)
+y = f.(x)
+df = fill(zero(Complex{eltype(x)}), size(x))
+epsilon = similar(real(x))
+df_ref = cos.(x) - im*sin.(x)
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}, eltype(df))
+central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}, eltype(df))
+
+@time @testset "Derivative single point f : R -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:forward}, Val{:Complex}), cos(π/4)-im*sin(π/4))) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, π/4, Val{:central}, Val{:Complex}), cos(π/4)-im*sin(π/4))) < 1e-7
+end
+
+@time @testset "Derivative StridedArray f : R -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref)) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref)) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref)) < 1e-6
+end
+
+#=
+x = x + im*x
+f(x) = abs2(x)
+y = f.(x)
+df = zeros(eltype(x), size(x))
+epsilon = similar(real(x))
+df_ref = 2*conj.(x)
+forward_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:forward}, eltype(df))
+central_cache = DiffEqDiffTools.DerivativeCache(x, y, epsilon, Val{:central}, eltype(df))
+@show typeof(DiffEqDiffTools.finite_difference_derivative(f, 1.+im*1., Val{:forward}, real(eltype(x))))
+
+@time @testset "Derivative single point f : C -> R tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, 1.+im*1., Val{:forward}, real(eltype(x))), 2.-2.*im) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, 1.+im*1., Val{:central}, real(eltype(x))), 2.-2.*im) < 1e-7
+end
+
+@time @testset "Derivative StridedArray f : C -> R tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, real(eltype(x))), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, real(eltype(x))), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, real(eltype(x)), y), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, real(eltype(x)), y), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, real(eltype(x)), y, epsilon), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, real(eltype(x)), y, epsilon), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, real(eltype(x))), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, real(eltype(x))), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, real(eltype(x)), y), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, real(eltype(x)), y), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, real(eltype(x)), y, epsilon), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, real(eltype(x)), y, epsilon), df_ref) < 1e-6
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
+end
+=#
+
+# Gradient tests
+f(x) = 2x[1] + x[2]^2
+x = rand(2)
+fx = f(x)
+df = fill(0.0, 2)
+df_ref = [2., 2*x[2]]
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
+complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
+
+@time @testset "Gradient of f:vector->scalar real-valued tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref)) < 1e-15
+end
+
+f(x) = 2x[1] + im*2x[1] + x[2]^2
+x = x + im*x
+fx = f(x)
+df = zero(x)
+df_ref = conj([2.0+2.0*im, 2.0*x[2]])
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+
+@time @testset "Gradient of f : C^N -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+end
+
+f(x) = sum(abs2, x)
+x = ones(2) * (1 + im)
+fx = f(x)
+df = zero(x)
+df_ref = 2*x
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+
+@time @testset "Gradient of f : C^N -> R tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+end
+
+f(x) = 2*x[1] + im*x[2]^2
+x = ones(2)
+fx = f(x)
+df = fill(zero(eltype(fx)), size(x))
+df_ref = [2.0, -im*2*x[2]]
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward},eltype(df))
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central},eltype(df))
+
+@time @testset "Gradient of f : R^N -> C tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(df)), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(df)), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, eltype(df)), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}, eltype(df)), df_ref)) < 1e-8
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+end
+
+f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
+x = 2π * rand()
+fx = fill(0.0,2)
+f(fx,x)
+df = fill(0.0,2)
+df_ref = [cos(x), -sin(x)]
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
+
+
+@time @testset "Gradient of f:scalar->vector real-valued tests" begin
+    @test_broken err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(x), Val{true}, fx), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(x), Val{true}, fx), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}, eltype(x), Val{true}, fx), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref)) < 1e-15
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref)) < 1e-15
+end
+
+f(df,x) = (df[1]=sin(x); df[2]=cos(x); df)
+x = (2π * rand()) * (1 + im)
+fx = fill(zero(typeof(x)), 2)
+f(fx,x)
+df = zero(fx)
+df_ref = [cos(x), -sin(x)]
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+
+@time @testset "Gradient of f:vector->scalar complex-valued tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, eltype(x), Val{true}, fx), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}, eltype(x), Val{true}, fx), df_ref)) < 1e-7
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref)) < 1e-7
+
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref)) < 1e-7
+end
+
+# Jacobian tests
+function f(fvec,x)
+    fvec[1] = (x[1]+3)*(x[2]^3-7)+18
+    fvec[2] = sin(x[2]*exp(x[1])-1)
+end
+x = rand(2); y = rand(2)
+f(y,x)
+J_ref = [[-7+x[2]^3 3*(3+x[1])*x[2]^2]; [exp(x[1])*x[2]*cos(1-exp(x[1])*x[2]) exp(x[1])*cos(1-exp(x[1])*x[2])]]
+J = zero(J_ref)
+df = zero(x)
+df_ref = diag(J_ref)
+epsilon = zero(x)
+forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward})
+central_cache = DiffEqDiffTools.JacobianCache(x)
+complex_cache = DiffEqDiffTools.JacobianCache(x,Val{:complex})
+
+@time @testset "Jacobian StridedArray real-valued tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, complex_cache), J_ref)) < 1e-14
+end
+
+function f(fvec,x)
+    fvec[1] = (im*x[1]+3)*(x[2]^3-7)+18
+    fvec[2] = sin(x[2]*exp(x[1])-1)
+end
+x = rand(2) + im*rand(2)
+y = similar(x)
+f(y,x)
+J_ref = [[im*(-7+x[2]^3) 3*(3+im*x[1])*x[2]^2]; [exp(x[1])*x[2]*cos(1-exp(x[1])*x[2]) exp(x[1])*cos(1-exp(x[1])*x[2])]]
+J = zero(J_ref)
+df = zero(x)
+df_ref = diag(J_ref)
+epsilon = zero(real.(x))
+forward_cache = DiffEqDiffTools.JacobianCache(x,Val{:forward})
+central_cache = DiffEqDiffTools.JacobianCache(x)
+
+@time @testset "Jacobian StridedArray f : C^N -> C^N tests" begin
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref)) < 1e-4
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref)) < 1e-8
+    @test (@inferred err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref)) < 1e-8
+end

--- a/test/old_interface_tests.jl
+++ b/test/old_interface_tests.jl
@@ -164,9 +164,9 @@ x = rand(2)
 fx = f(x)
 df = fill(0.0, 2)
 df_ref = [2., 2*x[2]]
-forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward}())
-central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central}())
-complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex}())
+forward_cache = DiffEqDiffTools.GradientCache(df,x,Val{:forward})
+central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
+complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
 
 @time @testset "Gradient of f:vector->scalar real-valued tests" begin
     @test (@inferred err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref)) < 1e-4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,4 @@
 using DiffEqDiffTools
-using Base.Test
+using Compat, Compat.Test
 
-tic()
-include("finitedifftests.jl")
-toc()
+@time include("finitedifftests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,3 +2,4 @@ using DiffEqDiffTools
 using Compat, Compat.Test
 
 @time include("finitedifftests.jl")
+@time include("old_interface_tests.jl")


### PR DESCRIPTION
In trying to clean a few things up for 0.7, I just started replacing `Val{T}`s with `Val(T)` or `Val{T}()` following the new documentation:
https://docs.julialang.org/en/latest/manual/types/#%22Value-types%22-1
This turned out to be a bigger change than I intended, especially because the value types are a part of the external API.
Therefore I added an "old API" file, which should stop dependencies from breaking so long as they don't construct Cache objects directly.