### PR TITLE
Allow passing epsilon_factor in gradient functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,17 +89,29 @@ This allocates either `fx` or `epsilon` if these are nothing and they are needed
 
 ```julia
 # Cache-less
-DiffEqDiffTools.finite_difference_gradient(f, x, fdtype::Type{T1}=Val{:central},
-                           returntype::Type{T2}=eltype(x),
-                           inplace::Type{Val{T3}}=Val{true})
-DiffEqDiffTools.finite_difference_gradient!(df, f, x, fdtype::Type{T1}=Val{:central},
-                            returntype::Type{T2}=eltype(df),
-                            inplace::Type{Val{T3}}=Val{true})
+DiffEqDiffTools.finite_difference_gradient(
+    f,
+    x,
+    fdtype::Type{T1}=Val{:central},
+    returntype::Type{T2}=eltype(x),
+    inplace::Type{Val{T3}}=Val{true};
+    [epsilon_factor])
+DiffEqDiffTools.finite_difference_gradient!(
+    df,
+    f,
+    x,
+    fdtype::Type{T1}=Val{:central},
+    returntype::Type{T2}=eltype(df),
+    inplace::Type{Val{T3}}=Val{true};
+    [epsilon_factor])
 
 # Cached
-DiffEqDiffTools.finite_difference_gradient!(df::AbstractArray{<:Number}, f,
-                            x::AbstractArray{<:Number},
-                            cache::GradientCache)
+DiffEqDiffTools.finite_difference_gradient!(
+    df::AbstractArray{<:Number},
+    f,
+    x::AbstractArray{<:Number},
+    cache::GradientCache;
+    [epsilon_factor])
 ```
 
 ### Allocating Cache Constructor

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ DiffEqDiffTools.finite_difference_derivative(
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(x),      # return type of f
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing)
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}} = nothing;
+    [epsilon_factor])
 
 DiffEqDiffTools.finite_difference_derivative!(
     df         :: AbstractArray{<:Number},
@@ -60,12 +61,16 @@ DiffEqDiffTools.finite_difference_derivative!(
     fdtype     :: Type{T1} = Val{:central},
     returntype :: Type{T2} = eltype(x),
     fx         :: Union{Nothing,AbstractArray{<:Number}} = nothing,
-    epsilon    :: Union{Nothing,AbstractArray{<:Real}}   = nothing)
+    epsilon    :: Union{Nothing,AbstractArray{<:Real}}   = nothing;
+    [epsilon_factor])
 
 # Cached
-DiffEqDiffTools.finite_difference_derivative!(df::AbstractArray{<:Number}, f,
-                              x::AbstractArray{<:Number},
-                              cache::DerivativeCache{T1,T2,fdtype,returntype})
+DiffEqDiffTools.finite_difference_derivative!(
+    df::AbstractArray{<:Number},
+    f,
+    x::AbstractArray{<:Number},
+    cache::DerivativeCache{T1,T2,fdtype,returntype};
+    [epsilon_factor])
 ```
 
 ### Allocating and Non-Allocating Constructor
@@ -150,15 +155,26 @@ into the differencing algorithm here.
 
 ```julia
 # Cache-less
-DiffEqDiffTools.finite_difference_jacobian(f, x::AbstractArray{<:Number},
-                           fdtype     :: Type{T1}=Val{:central},
-                           returntype :: Type{T2}=eltype(x),
-                           inplace    :: Type{Val{T3}}=Val{true})
+DiffEqDiffTools.finite_difference_jacobian(
+    f,
+    x          :: AbstractArray{<:Number},
+    fdtype     :: Type{T1}=Val{:central},
+    returntype :: Type{T2}=eltype(x),
+    inplace    :: Type{Val{T3}}=Val{true};
+    [epsilon_factor])
 
 # Cached
-DiffEqDiffTools.finite_difference_jacobian(f,x,cache::JacobianCache)
-DiffEqDiffTools.finite_difference_jacobian!(J::AbstractMatrix{<:Number},f,
-                            x::AbstractArray{<:Number},cache::JacobianCache)
+DiffEqDiffTools.finite_difference_jacobian(
+    f,
+    x,
+    cache::JacobianCache;
+    [epsilon_factor])
+DiffEqDiffTools.finite_difference_jacobian!(
+    J::AbstractMatrix{<:Number},
+    f,
+    x::AbstractArray{<:Number},
+    cache::JacobianCache;
+    [epsilon_factor])
 ```
 
 ### Allocating Cache Constructor

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -96,24 +96,31 @@ end
 
 @time @testset "Derivative StridedArray f : R -> C tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
 end
 
@@ -309,6 +316,7 @@ f_in = copy(y)
 
 @time @testset "Jacobian StridedArray real-valued tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, epsilon_factor=sqrt(eps())), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, f_in), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8
@@ -333,6 +341,7 @@ f_in = copy(y)
 
 @time @testset "Jacobian StridedArray f : C^N -> C^N tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, epsilon_factor=sqrt(eps())), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, f_in), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -169,14 +169,17 @@ complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
 
 @time @testset "Gradient of f:vector->scalar real-valued tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref) < 1e-15
 end
@@ -191,12 +194,15 @@ central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
 
 @time @testset "Gradient of f : C^N -> C tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
 end
 


### PR DESCRIPTION
It can be useful when the objective function is computed in lower precision e.g. when it's a numerical solution to an ODE.