### PR TITLE
Introduce absstep to specify the stepsize to use close to zero

### DIFF
--- a/src/finitediff.jl
+++ b/src/finitediff.jl
@@ -6,19 +6,19 @@ Very heavily inspired by Calculus.jl, but with an emphasis on performance and Di
 Compute the finite difference interval epsilon.
 Reference: Numerical Recipes, chapter 5.7.
 =#
-@inline function compute_epsilon(::Type{Val{:forward}}, x::T, eps_sqrt=sqrt(eps(real(T)))) where T<:Number
-    eps_sqrt * max(one(real(T)), abs(x))
+@inline function compute_epsilon(::Type{Val{:forward}}, x::T, relstep::Real, absstep::Real) where T<:Number
+    return relstep*abs(x) + absstep
 end
 
-@inline function compute_epsilon(::Type{Val{:central}}, x::T, eps_cbrt=cbrt(eps(real(T)))) where T<:Number
-    eps_cbrt * max(one(real(T)), abs(x))
+@inline function compute_epsilon(::Type{Val{:central}}, x::T, relstep::Real, absstep::Real) where T<:Number
+    return relstep*abs(x) + absstep
 end
 
-@inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Nothing,T}=nothing) where T<:Real
-    eps(T)
+@inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Nothing,T}=nothing, ::Union{Nothing,T}=nothing) where T<:Real
+    return eps(T)
 end
 
-@inline function compute_epsilon_factor(fdtype::DataType, ::Type{T}) where T<:Number
+@inline function default_relstep(fdtype::DataType, ::Type{T}) where T<:Number
     if fdtype==Val{:forward}
         return sqrt(eps(real(T)))
     elseif fdtype==Val{:central}

--- a/test/finitedifftests.jl
+++ b/test/finitedifftests.jl
@@ -96,31 +96,31 @@ end
 
 @time @testset "Derivative StridedArray f : R -> C tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative(f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:forward}, Complex{eltype(x)}, y, epsilon, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, Val{:central}, Complex{eltype(x)}, y, epsilon), df_ref) < 1e-6
 
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache), df_ref) < 1e-3
-    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-3
+    @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, forward_cache, relstep=sqrt(eps())), df_ref) < 1e-3
     @test err_func(DiffEqDiffTools.finite_difference_derivative!(df, f, x, central_cache), df_ref) < 1e-6
 end
 
@@ -176,17 +176,17 @@ complex_cache = DiffEqDiffTools.GradientCache(df,x,Val{:complex})
 
 @time @testset "Gradient of f:vector->scalar real-valued tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:complex}), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:complex}), df_ref) < 1e-15
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, complex_cache), df_ref) < 1e-15
 end
@@ -201,15 +201,15 @@ central_cache = DiffEqDiffTools.GradientCache(df,x,Val{:central})
 
 @time @testset "Gradient of f : C^N -> C tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:forward}, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient(f, x, Val{:central}), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:forward}, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, Val{:central}), df_ref) < 1e-8
 
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache), df_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, epsilon_factor=sqrt(eps())), df_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, forward_cache, relstep=sqrt(eps())), df_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_gradient!(df, f, x, central_cache), df_ref) < 1e-8
 end
 
@@ -316,7 +316,7 @@ f_in = copy(y)
 
 @time @testset "Jacobian StridedArray real-valued tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, epsilon_factor=sqrt(eps())), J_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, relstep=sqrt(eps())), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, f_in), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8
@@ -341,7 +341,7 @@ f_in = copy(y)
 
 @time @testset "Jacobian StridedArray f : C^N -> C^N tests" begin
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache), J_ref) < 1e-4
-    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, epsilon_factor=sqrt(eps())), J_ref) < 1e-4
+    @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, relstep=sqrt(eps())), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, forward_cache, f_in), J_ref) < 1e-4
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x, central_cache), J_ref) < 1e-8
     @test err_func(DiffEqDiffTools.finite_difference_jacobian(f, x), J_ref) < 1e-8


### PR DESCRIPTION
and rename epsilon_factor to relstep. Since we just introduced the `epsilon_factor` argument, I haven't deprecated it.

Setting the step size around zero can be important in applications and indeed I'm working on a project where the current default isn't a good choice.

The current version of this PR should have almost unchanged behavior for the current uses of the library. However, we might want to consider using a smaller absolute step size. This is effectively what https://cran.r-project.org/web/packages/numDeriv/numDeriv.pdf does and this can also be motivated by computing derivatives of `log` and `abs2` around zero, see

<img width="595" alt="Screen Shot 2019-05-25 at 20 25 45" src="https://user-images.githubusercontent.com/505001/58374224-f19deb80-7f3a-11e9-8c18-976d4b929d1c.png">
<img width="595" alt="Screen Shot 2019-05-25 at 20 27 32" src="https://user-images.githubusercontent.com/505001/58374225-f19deb80-7f3a-11e9-8a9d-5fddee035567.png">

Where "new" uses the square of the relative step size for the absolute step size. However, Pareto improvements only exist in books so some functions can lose on such a change.

<img width="597" alt="Screen Shot 2019-05-25 at 21 10 20" src="https://user-images.githubusercontent.com/505001/58374226-f19deb80-7f3a-11e9-91b2-2bf6dbe2da5a.png">

though I'm not sure if new error is really worrying.