### PR TITLE
Use max instead of + when combining abs- and relstep.

### DIFF
--- a/src/finitediff.jl
+++ b/src/finitediff.jl
@@ -7,11 +7,11 @@ Compute the finite difference interval epsilon.
 Reference: Numerical Recipes, chapter 5.7.
 =#
 @inline function compute_epsilon(::Type{Val{:forward}}, x::T, relstep::Real, absstep::Real) where T<:Number
-    return relstep*abs(x) + absstep
+    return max(relstep*abs(x), absstep)
 end
 
 @inline function compute_epsilon(::Type{Val{:central}}, x::T, relstep::Real, absstep::Real) where T<:Number
-    return relstep*abs(x) + absstep
+    return max(relstep*abs(x), absstep)
 end
 
 @inline function compute_epsilon(::Type{Val{:complex}}, x::T, ::Union{Nothing,T}=nothing, ::Union{Nothing,T}=nothing) where T<:Real


### PR DESCRIPTION
Så my last PR changed the behavior here just a tiny bit but enough to make 10 out of Optim's ~200k tests fail. This change should make the behavior exactly identical to version <10 and hence fix the breakage.