### PR TITLE
Optimize BandedBlockBandedMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ ArrayInterface = "1.1"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+BandedMatrices="aae01518-5342-5314-be14-df237901396f"
 
 [targets]
-test = ["Test","BlockBandedMatrices"]
+test = ["Test","BlockBandedMatrices","BandedMatrices"]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 
 [compat]
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1"
@@ -15,6 +15,7 @@ ArrayInterface = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
 
 [targets]
-test = ["Test"]
+test = ["Test","BlockBandedMatrices"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqDiffTools"
 uuid = "01453d9d-ee7c-5054-8395-0335cb756afa"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,7 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1"
-ArrayInterface = "1.1"
+ArrayInterface = ">= 1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/DiffEqDiffTools.jl
+++ b/src/DiffEqDiffTools.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module DiffEqDiffTools
 
-using LinearAlgebra, SparseArrays, StaticArrays, ArrayInterface
+using LinearAlgebra, SparseArrays, StaticArrays, ArrayInterface, BlockBandedMatrices
 
 import Base: resize!
 

--- a/src/DiffEqDiffTools.jl
+++ b/src/DiffEqDiffTools.jl
@@ -2,7 +2,7 @@ __precompile__()
 
 module DiffEqDiffTools
 
-using LinearAlgebra, SparseArrays, StaticArrays, ArrayInterface, BlockBandedMatrices
+using LinearAlgebra, SparseArrays, StaticArrays, ArrayInterface, Requires
 
 import Base: resize!
 

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -161,7 +161,7 @@ function finite_difference_jacobian!(
     end
     vfx = vec(fx)
 
-    if ArrayInterface.has_sparsestruct(sparsity)
+    if ArrayInterface.has_sparsestruct(sparsity) & !ArrayInterface.fast_column_indexing(sparsity)
         rows_index, cols_index = ArrayInterface.findstructralnz(sparsity)
     end
 
@@ -217,10 +217,18 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx1[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx1[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
                                 end
                             end
                         end
@@ -250,10 +258,18 @@ function finite_difference_jacobian!(
                     _vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx1[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx1[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
                                 end
                             end
                         end
@@ -325,10 +341,18 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / 2epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx1[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx1[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
                                 end
                             end
                         end
@@ -363,10 +387,18 @@ function finite_difference_jacobian!(
                     # vfx1 is the compressed Jacobian column
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx1[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx1[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
                                 end
                             end
                         end
@@ -427,10 +459,18 @@ function finite_difference_jacobian!(
                     @. vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx[rows_index[i]]
                                 end
                             end
                         end
@@ -461,10 +501,18 @@ function finite_difference_jacobian!(
                     vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for col_index in 1:n
-                            if color[col_index] == color_i
-                                for row_index in ArrayInterface.findstructralnz(J,col_index)
-                                    J[row_index,col_index]=vfx1[row_index]
+                        if ArrayInterface.fast_column_indexing(J)
+                            for col_index in 1:n
+                                if color[col_index] == color_i
+                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                        J[row_index,col_index]=vfx1[row_index]
+                                    end
+                                end
+                            end
+                        else
+                            for i in 1:length(cols_index)
+                                if color[cols_index[i]] == color_i
+                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
                                 end
                             end
                         end

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -217,10 +217,10 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx1[row_index]
                                     end
                                 end
@@ -258,10 +258,10 @@ function finite_difference_jacobian!(
                     _vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx1[row_index]
                                     end
                                 end
@@ -341,10 +341,10 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / 2epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx1[row_index]
                                     end
                                 end
@@ -387,10 +387,10 @@ function finite_difference_jacobian!(
                     # vfx1 is the compressed Jacobian column
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx1[row_index]
                                     end
                                 end
@@ -459,10 +459,10 @@ function finite_difference_jacobian!(
                     @. vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx[row_index]
                                     end
                                 end
@@ -501,10 +501,10 @@ function finite_difference_jacobian!(
                     vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        if ArrayInterface.fast_column_indexing(J)
+                        if ArrayInterface.fast_column_indexing(sparsity)
                             for col_index in 1:n
                                 if color[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
                                         J[row_index,col_index]=vfx1[row_index]
                                     end
                                 end

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -124,6 +124,30 @@ function finite_difference_jacobian(f, x::AbstractArray{<:Number},
     finite_difference_jacobian(f, x, cache, f_in; relstep=relstep, absstep=absstep, colorvec=colorvec, sparsity=sparsity, dir=dir)
 end
 
+macro _colorediteration(mode,vfx)
+    if mode.value==:columniteration
+        return esc(quote
+            for col_index in 1:n
+                if colorvec[col_index] == color_i
+                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
+                        J[row_index,col_index]=$vfx[row_index]
+                    end
+                end
+            end
+        end)
+    elseif mode.value==:indexing
+        return esc(quote
+        for i in 1:length(cols_index)
+            if colorvec[cols_index[i]] == color_i
+                J[rows_index[i],cols_index[i]] = $vfx[rows_index[i]]
+            end
+        end
+        end)
+    else
+        throw(ErrorException("Can't recognize mode: $mode"))
+    end
+end
+
 function finite_difference_jacobian(
     f,
     x,
@@ -218,19 +242,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx1[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx1)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx1)
                         end
                     else
                         #=
@@ -259,19 +273,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx1[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx1)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx1)
                         end
                     else
                         #=
@@ -342,19 +346,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx1[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx1)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx1)
                         end
                     else
                         #=
@@ -388,19 +382,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx1[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx1)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx1)
                         end
                     else
                         #=
@@ -460,19 +444,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx)
                         end
                     else
                         #=
@@ -502,19 +476,9 @@ function finite_difference_jacobian!(
 
                     if ArrayInterface.fast_scalar_indexing(x1)
                         if ArrayInterface.fast_column_indexing(sparsity)
-                            for col_index in 1:n
-                                if colorvec[col_index] == color_i
-                                    for row_index in ArrayInterface.findstructralnz(sparsity,col_index)
-                                        J[row_index,col_index]=vfx1[row_index]
-                                    end
-                                end
-                            end
+                            @_colorediteration(:columniteration,vfx1)
                         else
-                            for i in 1:length(cols_index)
-                                if colorvec[cols_index[i]] == color_i
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
-                                end
-                            end
+                            @_colorediteration(:indexing,vfx1)
                         end
                     else
                         #=

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -149,6 +149,7 @@ _use_findstructralnz(::SparseMatrixCSC) = false
 function __init__()
     @require BlockBandedMatrices="ffab5731-97b5-5995-9138-79e8c1846df0" begin
         _use_findstructralnz(::BlockBandedMatrices.BandedBlockBandedMatrix) = false
+        _use_findstructralnz(::BlockBandedMatrices.BlockBandedMatrix) = false
 
         @inline function _colorediteration!(Jac::BlockBandedMatrices.BandedBlockBandedMatrix,
                                             sparsity::BlockBandedMatrices.BandedBlockBandedMatrix,
@@ -177,7 +178,56 @@ function __init__()
                 end
             end
         end
+
+        @inline function _colorediteration!(Jac::BlockBandedMatrices.BlockBandedMatrix,
+                                            sparsity::BlockBandedMatrices.BlockBandedMatrix,
+                                            rows_index,cols_index,vfx,colorvec,color_i,ncols)
+            rs = BlockBandedMatrices.BlockSizes((BlockBandedMatrices.cumulsizes(Jac,1),)) # column block sizes
+            cs = BlockBandedMatrices.BlockSizes((BlockBandedMatrices.cumulsizes(Jac,2),))
+            b = BlockBandedMatrices.BlockArray(vfx,rs)
+            c = BlockBandedMatrices.BlockArray(colorvec,cs)
+            @inbounds for J=BlockBandedMatrices.Block.(1:BlockBandedMatrices.nblocks(Jac,2))
+                c_v = c.blocks[J.n[1]]
+                blockcolrange = BlockBandedMatrices.blockcolrange(Jac,J)
+                _,n = BlockBandedMatrices.blocksize(Jac,(blockcolrange[1].n[1],J.n[1]))
+                @inbounds for j = 1:n
+                    if c_v[j] == color_i
+                        @inbounds for K = blockcolrange
+                            V = view(Jac,K,J)
+                            b_v = b.blocks[K.n[1]]
+                            m = size(V,1)
+                            @inbounds for k = 1:m
+                                V[k,j] = b_v[k]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
     end
+
+    @require BandedMatrices = "aae01518-5342-5314-be14-df237901396f" begin
+
+        _use_findstructralnz(::BandedMatrices.BandedMatrix) = false
+
+        @inline function _colorediteration!(Jac::BandedMatrices.BandedMatrix,
+                                            sparsity::BandedMatrices.BandedMatrix,
+                                            rows_index,cols_index,vfx,colorvec,color_i,ncols)
+            nrows = size(Jac,1)
+            l,u = BandedMatrices.bandwidths(Jac)
+            #data = BandedMatrices.bandeddata(Jac)
+            @inbounds for col_index in max(1,1-l):min(ncols,ncols+u)
+                if colorvec[col_index] == color_i
+                    @inbounds for row_index in max(1,col_index-u):min(nrows,col_index+l)
+                        #data[u+row_index-col_index+1,col_index] = vfx[row_index]
+                        Jac[row_index,col_index]=vfx[row_index]
+                    end
+                end
+            end
+        end
+    end
+
 end
 
 function finite_difference_jacobian(

--- a/src/jacobians.jl
+++ b/src/jacobians.jl
@@ -217,12 +217,10 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx1[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx1[row_index]
                                 end
                             end
                         end
@@ -252,12 +250,10 @@ function finite_difference_jacobian!(
                     _vfx1 = (vfx1 - vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx1[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx1[row_index]
                                 end
                             end
                         end
@@ -329,12 +325,10 @@ function finite_difference_jacobian!(
                     @. vfx1 = (vfx1 - vfx) / 2epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx1[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx1[row_index]
                                 end
                             end
                         end
@@ -369,12 +363,10 @@ function finite_difference_jacobian!(
                     # vfx1 is the compressed Jacobian column
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx1[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx1[row_index]
                                 end
                             end
                         end
@@ -435,12 +427,10 @@ function finite_difference_jacobian!(
                     @. vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx[row_index]
                                 end
                             end
                         end
@@ -471,12 +461,10 @@ function finite_difference_jacobian!(
                     vfx = imag(vfx) / epsilon
 
                     if ArrayInterface.fast_scalar_indexing(x1)
-                        for i in 1:length(cols_index)
-                            if color[cols_index[i]] == color_i
-                                if J isa SparseMatrixCSC
-                                    J.nzval[i] = vfx1[rows_index[i]]
-                                else
-                                    J[rows_index[i],cols_index[i]] = vfx1[rows_index[i]]
+                        for col_index in 1:n
+                            if color[col_index] == color_i
+                                for row_index in ArrayInterface.findstructralnz(J,col_index)
+                                    J[row_index,col_index]=vfx1[row_index]
                                 end
                             end
                         end

--- a/test/coloring_tests.jl
+++ b/test/coloring_tests.jl
@@ -1,4 +1,4 @@
-using DiffEqDiffTools, LinearAlgebra, SparseArrays, Test, LinearAlgebra, BlockBandedMatrices, ArrayInterface
+using DiffEqDiffTools, LinearAlgebra, SparseArrays, Test, LinearAlgebra, BlockBandedMatrices, ArrayInterface, BandedMatrices
 
 fcalls = 0
 function f(dx,x)
@@ -94,9 +94,17 @@ function f(out, x)
 	return vec(out)
 end
 x = rand(10000)
-J = BandedBlockBandedMatrix(Ones(10000, 10000), (fill(100, 100), fill(100, 100)), (1, 1), (1, 1))
-Jsparse = sparse(J)
-colors = ArrayInterface.matrix_colors(J)
-DiffEqDiffTools.finite_difference_jacobian!(J, f, x, colorvec=colors)
-DiffEqDiffTools.finite_difference_jacobian!(Jsparse, f, x, colorvec=colors)
-@test J ≈ Jsparse
+Jbbb = BandedBlockBandedMatrix(Ones(10000, 10000), (fill(100, 100), fill(100, 100)), (1, 1), (1, 1))
+Jsparse = sparse(Jbbb)
+colorsbbb = ArrayInterface.matrix_colors(Jbbb)
+DiffEqDiffTools.finite_difference_jacobian!(Jbbb, f, x, colorvec=colorsbbb)
+DiffEqDiffTools.finite_difference_jacobian!(Jsparse, f, x, colorvec=colorsbbb)
+@test Jbbb ≈ Jsparse
+Jbb = BlockBandedMatrix(similar(Jsparse),(fill(100, 100), fill(100, 100)),(1,1));
+colorsbb = ArrayInterface.matrix_colors(Jbb)
+DiffEqDiffTools.finite_difference_jacobian!(Jbb, f, x, colorvec=colorsbb)
+@test Jbb ≈ Jsparse
+Jb = BandedMatrices.BandedMatrix(similar(Jsparse),(1,1))
+colorsb = ArrayInterface.matrix_colors(Jb)
+DiffEqDiffTools.finite_difference_jacobian!(Jb, f, x, colorvec=colorsb)
+@test Jb ≈ Jsparse

--- a/test/coloring_tests.jl
+++ b/test/coloring_tests.jl
@@ -82,6 +82,14 @@ DiffEqDiffTools.finite_difference_jacobian!(_J2,f,rand(30),Val{:complex},colorve
 @test fcalls == 3
 @test _J2 ≈ _J
 
+_Jb = BandedMatrices.BandedMatrix(similar(_J2),(1,1))
+DiffEqDiffTools.finite_difference_jacobian!(_Jb, f, rand(30), colorvec=colorvec=repeat(1:3,10))
+@test _Jb ≈ _J
+
+_Jtri = Tridiagonal(similar(_J2))
+DiffEqDiffTools.finite_difference_jacobian!(_Jtri, f, rand(30), colorvec=colorvec=repeat(1:3,10))
+@test _Jtri ≈ _J
+
 #https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/67#issuecomment-516871956
 function f(out, x)
 	x = reshape(x, 100, 100)
@@ -104,7 +112,3 @@ Jbb = BlockBandedMatrix(similar(Jsparse),(fill(100, 100), fill(100, 100)),(1,1))
 colorsbb = ArrayInterface.matrix_colors(Jbb)
 DiffEqDiffTools.finite_difference_jacobian!(Jbb, f, x, colorvec=colorsbb)
 @test Jbb ≈ Jsparse
-Jb = BandedMatrices.BandedMatrix(similar(Jsparse),(1,1))
-colorsb = ArrayInterface.matrix_colors(Jb)
-DiffEqDiffTools.finite_difference_jacobian!(Jb, f, x, colorvec=colorsb)
-@test Jb ≈ Jsparse


### PR DESCRIPTION
The original indexing based assignment is slow for BandedBlockBandedMatrix compared to CSC matrix (https://github.com/JuliaDiffEq/DiffEqDiffTools.jl/issues/67). This PR switch to a column-based iteration, the evaluation time of colored jacobian for BBBmatrix is reduced from 120 ms to 87ms while the performance for CSC matrix is kept the same. 